### PR TITLE
Fixed a bug where files that require checkout are not found if you're…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -46,7 +46,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 var checkedOut = false;
 
-                targetFile = folder.GetFile(file.Src);
+                targetFile = folder.GetFile(template.Connector.GetFilenamePart(file.Src));
 
                 if (targetFile != null)
                 {


### PR DESCRIPTION
… using a path in the file.Src name. Because they are not found it will result in a 'File is not checked out' error.