### PR TITLE
provision site group

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -49,24 +49,37 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 TermGroup group = termStore.Groups.FirstOrDefault(g => g.Id == modelTermGroup.Id);
                 if (group == null)
                 {
-                    group = termStore.Groups.FirstOrDefault(g => g.Name == modelTermGroup.Name);
-
-                    if (group == null)
+                    if (modelTermGroup.Name == "Site Collection")
                     {
-                        if (modelTermGroup.Id == Guid.Empty)
-                        {
-                            modelTermGroup.Id = Guid.NewGuid();
-                        }
-                        group = termStore.CreateGroup(parser.ParseString(modelTermGroup.Name), modelTermGroup.Id);
-
-                        group.Description = modelTermGroup.Description;
-
-                        termStore.CommitAll();
-                        web.Context.Load(group);
+                        var site = (web.Context as ClientContext).Site;
+                        group = termStore.GetSiteCollectionGroup(site, true);
+                        web.Context.Load(group, g => g.Name, g => g.Id, g => g.TermSets.Include(
+                            tset => tset.Name,
+                            tset => tset.Id));
                         web.Context.ExecuteQueryRetry();
+                    }
+                    else
+                    {
 
-                        newGroup = true;
+                        group = termStore.Groups.FirstOrDefault(g => g.Name == modelTermGroup.Name);
 
+                        if (group == null)
+                        {
+                            if (modelTermGroup.Id == Guid.Empty)
+                            {
+                                modelTermGroup.Id = Guid.NewGuid();
+                            }
+                            group = termStore.CreateGroup(parser.ParseString(modelTermGroup.Name), modelTermGroup.Id);
+
+                            group.Description = modelTermGroup.Description;
+
+                            termStore.CommitAll();
+                            web.Context.Load(group);
+                            web.Context.ExecuteQueryRetry();
+
+                            newGroup = true;
+
+                        }
                     }
                 }
 


### PR DESCRIPTION
Moved PR from here https://github.com/OfficeDev/PnP/pull/1136

@erwinvanhunen , regarding new property for term group element. First I was thinking the same, but the problem with site collection term groups is that there is no straight way to create site collection term group using CSOM (and probably SSOM as well). The only available API is termStore.GetSiteCollectionGroup, where you can set createIfNotExist=true. This will create "default" site collection term group, called like "Site Collection - {site url}", and there is no way to change group name or id during creation. So making attribute like IsSiteCollectionGroup does not make much sense.
It may be a good idea to add special element inside TermGroups element (something like SiteCollectionTermGroup), but it requires schema and model changes. So I chose the simplest way, unfortunately it not that straight forward.