### PR TITLE
Improved SecurityExtensions methods to be called on any SecurableObject (i.e. Web, List, ListItem).

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Enums;
 using OfficeDevPnP.Core.Tests;
+using OfficeDevPnP.Core.AppModelExtensions;
 
 namespace Microsoft.SharePoint.Client.Tests
 {
@@ -161,6 +162,154 @@ namespace Microsoft.SharePoint.Client.Tests
             }
         }
 
+		[TestMethod]
+		public void AddPermissionLevelToGroupSubSiteTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				var subSite = CreateTestTeamSubSite(clientContext.Web);
+
+				if (!subSite.IsPropertyAvailable(w => w.HasUniqueRoleAssignments))
+				{
+					clientContext.Load(subSite, w => w.HasUniqueRoleAssignments);
+					clientContext.ExecuteQueryRetry();
+				}
+
+				if (!subSite.HasUniqueRoleAssignments)
+				{
+					subSite.BreakRoleInheritance(false, true);
+				}
+
+				// Test
+				subSite.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, false);
+
+				//Get Group
+				Group group = subSite.SiteGroups.GetByName(_testGroupName);
+				clientContext.ExecuteQueryRetry();
+
+				//Assert
+				Assert.IsTrue(CheckPermissionOnPrinciple(subSite, group, RoleType.Contributor));
+
+				//Teardown
+				subSite.DeleteObject();
+				clientContext.ExecuteQueryRetry();
+			}
+		}
+
+		[TestMethod]
+		public void AddPermissionLevelToGroupListTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				var list = clientContext.Web.CreateList(ListTemplateType.GenericList, GetRandomString(), false);
+
+				if (!list.IsPropertyAvailable(w => w.HasUniqueRoleAssignments))
+				{
+					clientContext.Load(list, w => w.HasUniqueRoleAssignments);
+					clientContext.ExecuteQueryRetry();
+				}
+
+				if (!list.HasUniqueRoleAssignments)
+				{
+					list.BreakRoleInheritance(false, true);
+				}
+
+				// Test
+				list.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, false);
+
+				//Get Group
+				Group group = list.ParentWeb.SiteGroups.GetByName(_testGroupName);
+				clientContext.ExecuteQueryRetry();
+
+				//Assert
+				Assert.IsTrue(CheckPermissionOnPrinciple(list, group, RoleType.Contributor));
+
+				//Teardown
+				list.DeleteObject();
+				clientContext.ExecuteQueryRetry();
+			}
+		}
+
+		[TestMethod]
+		public void AddPermissionLevelToGroupListItemTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				var list = clientContext.Web.CreateList(ListTemplateType.GenericList, GetRandomString(), false);
+				var item = list.AddItem(new ListItemCreationInformation());
+				item["Title"] = "Test";
+				item.Update();
+				clientContext.Load(item);
+				clientContext.ExecuteQueryRetry();
+
+				if (!item.IsPropertyAvailable(w => w.HasUniqueRoleAssignments))
+				{
+					clientContext.Load(item, w => w.HasUniqueRoleAssignments);
+					clientContext.ExecuteQueryRetry();
+				}
+
+				if (!item.HasUniqueRoleAssignments)
+				{
+					item.BreakRoleInheritance(false, true);
+				}
+
+				//Get Group
+				Group group = list.ParentWeb.SiteGroups.GetByName(_testGroupName);
+				clientContext.ExecuteQueryRetry();
+
+				// Test
+				item.AddPermissionLevelToPrincipal(group, RoleType.Contributor, false);
+
+				//Assert
+				Assert.IsTrue(CheckPermissionOnPrinciple(item, group, RoleType.Contributor));
+
+				//Teardown
+				list.DeleteObject();
+				clientContext.ExecuteQueryRetry();
+			}
+		}
+
+		[TestMethod]
+		public void RemovePermissionLevelFromGroupSubSiteTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				var subSite = CreateTestTeamSubSite(clientContext.Web);
+
+				if (!subSite.IsPropertyAvailable(w => w.HasUniqueRoleAssignments))
+				{
+					clientContext.Load(subSite, w => w.HasUniqueRoleAssignments);
+					clientContext.ExecuteQueryRetry();
+				}
+
+				if (!subSite.HasUniqueRoleAssignments)
+				{
+					subSite.BreakRoleInheritance(true, true);
+				}
+
+				//Get Group
+				Group group = subSite.SiteGroups.GetByName(_testGroupName);
+				clientContext.ExecuteQueryRetry();
+
+				subSite.AddPermissionLevelToPrincipal(group, RoleType.Contributor);
+				subSite.AddPermissionLevelToPrincipal(group, RoleType.Editor);
+
+				// Test
+				subSite.RemovePermissionLevelFromPrincipal(group, RoleType.Contributor);
+
+				//Assert
+				Assert.IsFalse(CheckPermissionOnPrinciple(subSite, group, RoleType.Contributor));
+
+				//Teardown
+				subSite.DeleteObject();
+				clientContext.ExecuteQueryRetry();
+			}
+		}
+
         [TestMethod]
         public void AddPermissionLevelByRoleDefToGroupTest()
         {
@@ -211,7 +360,7 @@ namespace Microsoft.SharePoint.Client.Tests
             using (ClientContext clientContext = TestCommon.CreateClientContext())
             {
                 Web web = clientContext.Web;
-
+				
                 //Setup: Make sure permission does not already exist
                 web.RemovePermissionLevelFromUser(_userLogin, "Approve");
 
@@ -288,13 +437,13 @@ namespace Microsoft.SharePoint.Client.Tests
         #endregion
 
         #region helper methods
-        private bool CheckPermissionOnPrinciple(Web web, Principal principle, RoleType roleType)
+        private bool CheckPermissionOnPrinciple(SecurableObject securableObject, Principal principle, RoleType roleType)
         {
             //Get Roles for the User
             RoleDefinitionBindingCollection roleDefinitionBindingCollection =
-                web.RoleAssignments.GetByPrincipal(principle).RoleDefinitionBindings;
-            web.Context.Load(roleDefinitionBindingCollection);
-            web.Context.ExecuteQueryRetry();
+                securableObject.RoleAssignments.GetByPrincipal(principle).RoleDefinitionBindings;
+            securableObject.Context.Load(roleDefinitionBindingCollection);
+            securableObject.Context.ExecuteQueryRetry();
 
             //Check if assigned role is found
             bool roleExists = false;
@@ -309,13 +458,13 @@ namespace Microsoft.SharePoint.Client.Tests
             return roleExists;
         }
 
-        private bool CheckPermissionOnPrinciple(Web web, Principal principle, string roleDefinitionName)
+        private bool CheckPermissionOnPrinciple(SecurableObject securableObject, Principal principle, string roleDefinitionName)
         {
             //Get Roles for the User
             RoleDefinitionBindingCollection roleDefinitionBindingCollection =
-                web.RoleAssignments.GetByPrincipal(principle).RoleDefinitionBindings;
-            web.Context.Load(roleDefinitionBindingCollection);
-            web.Context.ExecuteQueryRetry();
+                securableObject.RoleAssignments.GetByPrincipal(principle).RoleDefinitionBindings;
+            securableObject.Context.Load(roleDefinitionBindingCollection);
+            securableObject.Context.ExecuteQueryRetry();
 
             //Check if assigned role is found
             bool roleExists = false;
@@ -328,7 +477,36 @@ namespace Microsoft.SharePoint.Client.Tests
             }
 
             return roleExists;
-        }
+        
+		}
+
+	    private Web CreateTestTeamSubSite(Web parentWeb)
+	    {
+		    var siteUrl = GetRandomString();
+		    var webInfo = new WebCreationInformation
+		    {
+			    Title = siteUrl,
+			    Url = siteUrl,
+			    Description = siteUrl,
+			    Language = 1033,
+			    UseSamePermissionsAsParentSite = true,
+			    WebTemplate = "STS#0"
+		    };
+
+		    var web = parentWeb.Webs.Add(webInfo);
+			parentWeb.Context.Load(web);
+			parentWeb.Context.ExecuteQueryRetry();
+
+		    return web;
+
+	    }
+
+	    private string GetRandomString()
+	    {
+			var chars = "abcdefghijklmnopqrstuvwxyz";
+			var random = new Random();
+			return new string(Enumerable.Repeat(chars, 4).Select(s => s[random.Next(s.Length)]).ToArray());
+	    }
         #endregion
     }
 }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ClientObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ClientObjectExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.Core.AppModelExtensions
+{
+	public static class ClientObjectExtensions
+	{
+		public static bool IsPropertyAvailable<T>(this T clientObject, Expression<Func<T, object>> propertySelector) where T : ClientObject
+		{
+			var body = propertySelector.Body as MemberExpression;
+
+			if (body == null)
+			{
+				body = ((UnaryExpression)propertySelector.Body).Operand as MemberExpression;
+			}
+
+			return clientObject.IsPropertyAvailable(body.Member.Name);
+		}
+
+		public static bool IsObjectPropertyInstantiated<T>(this T clientObject, Expression<Func<T, object>> propertySelector) where T : ClientObject
+		{
+			var body = propertySelector.Body as MemberExpression;
+
+			if (body == null)
+			{
+				body = ((UnaryExpression)propertySelector.Body).Operand as MemberExpression;
+			}
+
+			return clientObject.IsObjectPropertyInstantiated(body.Member.Name);
+		}
+	}
+}

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/SecurableObjectExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.Core.AppModelExtensions
+{
+	public static class SecurableObjectExtensions
+	{
+		public static Web GetAssociatedWeb(this SecurableObject securable)
+		{
+			if (securable is Web)
+			{
+				return (Web)securable;
+			}
+
+			if (securable is List)
+			{
+				var list = (List)securable;
+				var web = list.ParentWeb;
+				securable.Context.Load(web);
+				securable.Context.ExecuteQueryRetry();
+
+				return web;
+			}
+
+			if (securable is ListItem)
+			{
+				var listItem = (ListItem)securable;
+				var web = listItem.ParentList.ParentWeb;
+				securable.Context.Load(web);
+				securable.Context.ExecuteQueryRetry();
+
+				return web;
+			}
+
+			throw new Exception("Only Web, List, ListItem supported as SecurableObjects");
+		}
+	}
+}

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.Online.SharePoint.TenantManagement;
+using OfficeDevPnP.Core.AppModelExtensions;
 using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Enums;
 using OfficeDevPnP.Core.Utilities;
@@ -629,30 +630,29 @@ namespace Microsoft.SharePoint.Client
         /// <summary>
         /// Add a permission level (e.g.Contribute, Reader,...) to a user
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="userLoginName">Loginname of the user</param>
         /// <param name="permissionLevel">Permission level to add</param>
         /// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that user</param>
-        public static void AddPermissionLevelToUser(this Web web, string userLoginName, RoleType permissionLevel, bool removeExistingPermissionLevels = false)
+        public static void AddPermissionLevelToUser(this SecurableObject securableObject, string userLoginName, RoleType permissionLevel, bool removeExistingPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(userLoginName))
                 throw new ArgumentNullException("userLoginName");
 
-            User user = web.EnsureUser(userLoginName);
-            web.Context.Load(user);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
-            web.AddPermissionLevelImplementation(user, roleDefinition, removeExistingPermissionLevels);
+	        Web web = securableObject.GetAssociatedWeb();
+
+			User user = web.EnsureUser(userLoginName);
+			securableObject.AddPermissionLevelToPrincipal(user, permissionLevel, removeExistingPermissionLevels);
         }
 
         /// <summary>
         /// Add a role definition (e.g.Contribute, Read, Approve) to a user
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="userLoginName">Loginname of the user</param>
         /// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Hierarchy|Restricted Read. Use the correct name of the language of the root site you are using</param>
         /// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that user</param>
-        public static void AddPermissionLevelToUser(this Web web, string userLoginName, string roleDefinitionName, bool removeExistingPermissionLevels = false)
+		public static void AddPermissionLevelToUser(this SecurableObject securableObject, string userLoginName, string roleDefinitionName, bool removeExistingPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(userLoginName))
                 throw new ArgumentNullException("userLoginName");
@@ -660,63 +660,105 @@ namespace Microsoft.SharePoint.Client
             if (string.IsNullOrEmpty(userLoginName))
                 throw new ArgumentNullException("roleDefinitionName");
 
-            User user = web.EnsureUser(userLoginName);
-            web.Context.Load(user);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
-            web.AddPermissionLevelImplementation(user, roleDefinition, removeExistingPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			User user = web.EnsureUser(userLoginName);
+			securableObject.AddPermissionLevelToPrincipal(user, roleDefinitionName, removeExistingPermissionLevels);
         }
 
         /// <summary>
         /// Add a permission level (e.g.Contribute, Reader,...) to a group
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="groupName">Name of the group</param>
         /// <param name="permissionLevel">Permission level to add</param>
         /// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that group</param>
-        public static void AddPermissionLevelToGroup(this Web web, string groupName, RoleType permissionLevel, bool removeExistingPermissionLevels = false)
+		public static void AddPermissionLevelToGroup(this SecurableObject securableObject, string groupName, RoleType permissionLevel, bool removeExistingPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(groupName))
                 throw new ArgumentNullException("groupName");
 
-            var group = web.SiteGroups.GetByName(groupName);
-            web.Context.Load(group);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
-            web.AddPermissionLevelImplementation(group, roleDefinition, removeExistingPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			var group = web.SiteGroups.GetByName(groupName);
+
+			securableObject.AddPermissionLevelToPrincipal(group, permissionLevel, removeExistingPermissionLevels);
         }
+
+		/// <summary>
+		/// Add a permission level (e.g.Contribute, Reader,...) to a group
+		/// </summary>
+		/// <param name="securableObject">Web to operate against</param>
+		/// <param name="principal">Principal to add permission to</param>
+		/// <param name="permissionLevel">Permission level to add</param>
+		/// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that group</param>
+		public static void AddPermissionLevelToPrincipal(this SecurableObject securableObject, Principal principal, RoleType permissionLevel, bool removeExistingPermissionLevels = false)
+		{
+			if (principal == null)
+				throw new ArgumentNullException("principal");
+
+			Web web = securableObject.GetAssociatedWeb();
+
+			securableObject.Context.Load(principal);
+			securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
+			securableObject.AddPermissionLevelImplementation(principal, roleDefinition, removeExistingPermissionLevels);
+		}
 
         /// <summary>
         /// Add a role definition (e.g.Contribute, Read, Approve) to a group
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="groupName">Name of the group</param>
         /// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Hierarchy|Restricted Read. Use the correct name of the language of the root site you are using</param>
         /// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that group</param>
-        public static void AddPermissionLevelToGroup(this Web web, string groupName, string roleDefinitionName, bool removeExistingPermissionLevels = false)
+		public static void AddPermissionLevelToGroup(this SecurableObject securableObject, string groupName, string roleDefinitionName, bool removeExistingPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(groupName))
                 throw new ArgumentNullException("groupName");
 
-            if (string.IsNullOrEmpty(groupName))
+			if (string.IsNullOrEmpty(roleDefinitionName))
                 throw new ArgumentNullException("roleDefinitionName");
 
-            var group = web.SiteGroups.GetByName(groupName);
-            web.Context.Load(group);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
-            web.AddPermissionLevelImplementation(group, roleDefinition, removeExistingPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			var group = web.SiteGroups.GetByName(groupName);
+
+			securableObject.AddPermissionLevelToPrincipal(group, roleDefinitionName, removeExistingPermissionLevels);
         }
 
-        private static void AddPermissionLevelImplementation(this Web web, Principal principal, RoleDefinition roleDefinition, bool removeExistingPermissionLevels = false)
+		/// <summary>
+		/// Add a role definition (e.g.Contribute, Read, Approve) to a group
+		/// </summary>
+		/// <param name="securableObject">Web to operate against</param>
+		/// <param name="principal">Principal to add permission to</param>
+		/// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Hierarchy|Restricted Read. Use the correct name of the language of the root site you are using</param>
+		/// <param name="removeExistingPermissionLevels">Set to true to remove all other permission levels for that group</param>
+		public static void AddPermissionLevelToPrincipal(this SecurableObject securableObject, Principal principal, string roleDefinitionName, bool removeExistingPermissionLevels = false)
+		{
+			if (principal == null)
+				throw new ArgumentNullException("principal");
+
+			if (string.IsNullOrEmpty(roleDefinitionName))
+				throw new ArgumentNullException("roleDefinitionName");
+
+			Web web = securableObject.GetAssociatedWeb();
+
+			securableObject.Context.Load(principal);
+			securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
+			securableObject.AddPermissionLevelImplementation(principal, roleDefinition, removeExistingPermissionLevels);
+		}
+
+        private static void AddPermissionLevelImplementation(this SecurableObject securableObject, Principal principal, RoleDefinition roleDefinition, bool removeExistingPermissionLevels = false)
         {
             if (principal != null)
             {
                 bool processed = false;
 
-                RoleAssignmentCollection rac = web.RoleAssignments;
-                web.Context.Load(rac);
-                web.Context.ExecuteQueryRetry();
+                RoleAssignmentCollection rac = securableObject.RoleAssignments;
+                securableObject.Context.Load(rac);
+                securableObject.Context.ExecuteQueryRetry();
 
                 //Find the roles assigned to the principal
                 foreach (RoleAssignment ra in rac)
@@ -726,12 +768,10 @@ namespace Microsoft.SharePoint.Client
                     {
                         // load the role definitions for this role assignment
                         RoleDefinitionBindingCollection rdc = ra.RoleDefinitionBindings;
-                        web.Context.Load(rdc);
-                        web.Context.Load(web.RoleDefinitions);
-                        web.Context.ExecuteQueryRetry();
+                        securableObject.Context.Load(rdc);
+                        securableObject.Context.ExecuteQueryRetry();
 
                         // Load the role definition to add (e.g. contribute)
-                        //RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
                         if (removeExistingPermissionLevels)
                         {
                             // Remove current role definitions by removing all current role definitions
@@ -743,7 +783,7 @@ namespace Microsoft.SharePoint.Client
                         //update                        
                         ra.ImportRoleDefinitionBindings(rdc);
                         ra.Update();
-                        web.Context.ExecuteQueryRetry();
+                        securableObject.Context.ExecuteQueryRetry();
 
                         // Leave the for each loop
                         processed = true;
@@ -754,10 +794,10 @@ namespace Microsoft.SharePoint.Client
                 // For a principal without role definitions set we follow a different code path
                 if (!processed)
                 {
-                    RoleDefinitionBindingCollection rdc = new RoleDefinitionBindingCollection(web.Context);
+                    RoleDefinitionBindingCollection rdc = new RoleDefinitionBindingCollection(securableObject.Context);
                     rdc.Add(roleDefinition);
-                    web.RoleAssignments.Add(principal, rdc);
-                    web.Context.ExecuteQueryRetry();
+                    securableObject.RoleAssignments.Add(principal, rdc);
+                    securableObject.Context.ExecuteQueryRetry();
                 }
             }
         }
@@ -765,86 +805,132 @@ namespace Microsoft.SharePoint.Client
         /// <summary>
         /// Removes a permission level from a user
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="userLoginName">Loginname of user</param>
         /// <param name="permissionLevel">Permission level to remove. If null all permission levels are removed</param>
         /// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
-        public static void RemovePermissionLevelFromUser(this Web web, string userLoginName, RoleType permissionLevel, bool removeAllPermissionLevels = false)
+        public static void RemovePermissionLevelFromUser(this SecurableObject securableObject, string userLoginName, RoleType permissionLevel, bool removeAllPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(userLoginName))
                 throw new ArgumentNullException("userLoginName");
 
-            User user = web.EnsureUser(userLoginName);
-            web.Context.Load(user);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
-            web.RemovePermissionLevelImplementation(user, roleDefinition, removeAllPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			User user = web.EnsureUser(userLoginName);
+
+			securableObject.RemovePermissionLevelFromPrincipal(user, permissionLevel, removeAllPermissionLevels);
         }
+
+		/// <summary>
+		/// Removes a permission level from a user
+		/// </summary>
+		/// <param name="securableObject">Web to operate against</param>
+		/// <param name="principal">Principal to remove permission from</param>
+		/// <param name="permissionLevel">Permission level to remove. If null all permission levels are removed</param>
+		/// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
+		public static void RemovePermissionLevelFromPrincipal(this SecurableObject securableObject, Principal principal, RoleType permissionLevel, bool removeAllPermissionLevels = false)
+		{
+			if (principal == null)
+				throw new ArgumentNullException("principal");
+
+			Web web = securableObject.GetAssociatedWeb();
+
+			securableObject.Context.Load(principal);
+			securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
+
+			securableObject.RemovePermissionLevelImplementation(principal, roleDefinition, removeAllPermissionLevels);
+		}
 
         /// <summary>
         /// Removes a permission level from a user
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="userLoginName">Loginname of user</param>
         /// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Heirarchy|Restricted Read. Use the correct name of the language of the site you are using</param>
         /// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
-        public static void RemovePermissionLevelFromUser(this Web web, string userLoginName, string roleDefinitionName, bool removeAllPermissionLevels = false)
+        public static void RemovePermissionLevelFromUser(this SecurableObject securableObject, string userLoginName, string roleDefinitionName, bool removeAllPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(userLoginName))
                 throw new ArgumentNullException("userLoginName");
 
-            User user = web.EnsureUser(userLoginName);
-            web.Context.Load(user);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
-            web.RemovePermissionLevelImplementation(user, roleDefinition, removeAllPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			User user = web.EnsureUser(userLoginName);
+
+			securableObject.RemovePermissionLevelFromPrincipal(user, roleDefinitionName, removeAllPermissionLevels);
         }
+
+		/// <summary>
+		/// Removes a permission level from a user
+		/// </summary>
+		/// <param name="securableObject">Web to operate against</param>
+		/// <param name="principal">Principal to remove permission from</param>
+		/// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Heirarchy|Restricted Read. Use the correct name of the language of the site you are using</param>
+		/// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
+		public static void RemovePermissionLevelFromPrincipal(this SecurableObject securableObject, Principal principal, string roleDefinitionName, bool removeAllPermissionLevels = false)
+		{
+			if (principal == null)
+				throw new ArgumentNullException("principal");
+
+			Web web = securableObject.GetAssociatedWeb();
+
+			securableObject.Context.Load(principal);
+			securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
+
+			securableObject.RemovePermissionLevelImplementation(principal, roleDefinition, removeAllPermissionLevels);
+		}
 
         /// <summary>
         /// Removes a permission level from a group
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="groupName">name of the group</param>
         /// <param name="permissionLevel">Permission level to remove. If null all permission levels are removed</param>
         /// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
-        public static void RemovePermissionLevelFromGroup(this Web web, string groupName, RoleType permissionLevel, bool removeAllPermissionLevels = false)
+        public static void RemovePermissionLevelFromGroup(this SecurableObject securableObject, string groupName, RoleType permissionLevel, bool removeAllPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(groupName))
                 throw new ArgumentNullException("groupName");
 
-            var group = web.SiteGroups.GetByName(groupName);
-            web.Context.Load(group);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
-            web.RemovePermissionLevelImplementation(group, roleDefinition, removeAllPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			var group = web.SiteGroups.GetByName(groupName);
+            securableObject.Context.Load(group);
+            securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByType(permissionLevel);
+            securableObject.RemovePermissionLevelImplementation(group, roleDefinition, removeAllPermissionLevels);
         }
 
         /// <summary>
         /// Removes a permission level from a group
         /// </summary>
-        /// <param name="web">Web to operate against</param>
+        /// <param name="securableObject">Web to operate against</param>
         /// <param name="groupName">name of the group</param>
         /// <param name="roleDefinitionName">Name of the role definition to add, Full Control|Design|Contribute|Read|Approve|Manage Heirarchy|Restricted Read. Use the correct name of the language of the site you are using</param>
         /// <param name="removeAllPermissionLevels">Set to true to remove all permission level.</param>
-        public static void RemovePermissionLevelFromGroup(this Web web, string groupName, string roleDefinitionName, bool removeAllPermissionLevels = false)
+		public static void RemovePermissionLevelFromGroup(this SecurableObject securableObject, string groupName, string roleDefinitionName, bool removeAllPermissionLevels = false)
         {
             if (string.IsNullOrEmpty(groupName))
                 throw new ArgumentNullException("groupName");
 
-            var group = web.SiteGroups.GetByName(groupName);
-            web.Context.Load(group);
-            web.Context.ExecuteQueryRetry();
-            RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
-            web.RemovePermissionLevelImplementation(group, roleDefinition, removeAllPermissionLevels);
+			Web web = securableObject.GetAssociatedWeb();
+
+			var group = web.SiteGroups.GetByName(groupName);
+            securableObject.Context.Load(group);
+            securableObject.Context.ExecuteQueryRetry();
+			RoleDefinition roleDefinition = web.RoleDefinitions.GetByName(roleDefinitionName);
+            securableObject.RemovePermissionLevelImplementation(group, roleDefinition, removeAllPermissionLevels);
         }
 
-        private static void RemovePermissionLevelImplementation(this Web web, Principal principal, RoleDefinition roleDefinition, bool removeAllPermissionLevels = false)
+        private static void RemovePermissionLevelImplementation(this SecurableObject securableObject, Principal principal, RoleDefinition roleDefinition, bool removeAllPermissionLevels = false)
         {
             if (principal != null)
             {
-                RoleAssignmentCollection rac = web.RoleAssignments;
-                web.Context.Load(rac);
-                web.Context.ExecuteQueryRetry();
+                RoleAssignmentCollection rac = securableObject.RoleAssignments;
+                securableObject.Context.Load(rac);
+                securableObject.Context.ExecuteQueryRetry();
 
                 //Find the roles assigned to the principal
                 foreach (RoleAssignment ra in rac)
@@ -854,9 +940,8 @@ namespace Microsoft.SharePoint.Client
                     {
                         // load the role definitions for this role assignment
                         RoleDefinitionBindingCollection rdc = ra.RoleDefinitionBindings;
-                        web.Context.Load(rdc);
-                        web.Context.Load(web.RoleDefinitions);
-                        web.Context.ExecuteQueryRetry();
+                        securableObject.Context.Load(rdc);
+                        securableObject.Context.ExecuteQueryRetry();
 
                         if (removeAllPermissionLevels)
                         {
@@ -872,7 +957,7 @@ namespace Microsoft.SharePoint.Client
                         //update                      
                         ra.ImportRoleDefinitionBindings(rdc);
                         ra.Update();
-                        web.Context.ExecuteQueryRetry();
+                        securableObject.Context.ExecuteQueryRetry();
 
                         // Leave the for each loop
                         break;

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -242,6 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppModelExtensions\ClientContextExtensions.cs" />
+    <Compile Include="AppModelExtensions\ClientObjectExtensions.cs" />
     <Compile Include="AppModelExtensions\Deprecated\BrandingExtensions.deprecated.cs" />
     <Compile Include="AppModelExtensions\Deprecated\ClientContextExtensions.deprecated.cs" />
     <Compile Include="AppModelExtensions\Deprecated\FeatureExtensions.deprecated.cs" />
@@ -269,6 +270,7 @@
     <Compile Include="AppModelExtensions\ProvisioningExtensions.cs" />
     <Compile Include="AppModelExtensions\RecordsManagementExtensions.cs" />
     <Compile Include="AppModelExtensions\SearchExtensions.cs" />
+    <Compile Include="AppModelExtensions\SecurableObjectExtensions.cs" />
     <Compile Include="AppModelExtensions\TaxonomyExtensions.cs" />
     <Compile Include="AppModelExtensions\TenantExtensions.cs" />
     <Compile Include="AppModelExtensions\VariationExtensions.cs" />


### PR DESCRIPTION
Current implementation relies only on Web object to apply permission to. Some methods reworked to accept any SecurableObject (Web, List, ListItem).   
Note according breaking inheritance: caller should take care about breaking inheritance when make a call to AddPermissions....