### PR TITLE
Deploy files to RootWeb if the token points to the root

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
@@ -23,5 +23,10 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
             }
             return CacheValue;
         }
+
+        public override bool IsRootWebToken
+        {
+            get { return true; }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -49,5 +49,13 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers
         {
             this.CacheValue = null;
         }
+
+        /// <summary>
+        /// Determines if this token automatically corresponds to a Root Web URL
+        /// </summary>
+        public virtual bool IsRootWebToken
+        {
+            get { return false; }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -186,5 +186,49 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return input;
         }
 
+        /// <summary>
+        /// Determines whether the specified <paramref name="input"/> contains a token that will be converted into a URL that belongs to the Root Web
+        /// </summary>
+        /// <param name="input">The input string that contains tokens that should be converted.</param>
+        /// <param name="tokensToSkip">Tokens that should be skipped</param>
+        /// <returns><c>true</c> if the input string contains tokens that will be converted to a URL that belongs to the Root Web</returns>
+        public bool ContainsRootWebToken(string input, params string[] tokensToSkip)
+        {
+            if (!string.IsNullOrEmpty(input))
+            {
+                foreach (var token in _tokens)
+                {
+                    if (tokensToSkip != null)
+                    {
+                        if (token.GetTokens().Except(tokensToSkip, StringComparer.InvariantCultureIgnoreCase).Any())
+                        {
+                            foreach (var filteredToken in token.GetTokens().Except(tokensToSkip, StringComparer.InvariantCultureIgnoreCase))
+                            {
+                                var regex = token.GetRegexForToken(filteredToken);
+                                if (regex.IsMatch(input))
+                                {
+                                    if (token.IsRootWebToken)
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var regex in token.GetRegex().Where(regex => regex.IsMatch(input)))
+                        {
+                            if (token.IsRootWebToken)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Fix for issue  #44. I added a new property to the tokens that show if the replaced token is always located in the Root Web. A new method in the parser analyzes mimicks the subtitution and determines if a token replacement uses the Root Web. The deployment routine uses this new value to dynamically switch the deployment target between local subsite and root web.