### PR TITLE
Fix for FileFolderExtensions.SetFileProperties to take into account checkoutIfRequired parameter

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -1011,7 +1011,7 @@ namespace Microsoft.SharePoint.Client
                         }
                     }
 
-                    if (checkOutRequired && file.CheckOutType == CheckOutType.None)
+                    if (checkoutIfRequired && checkOutRequired && file.CheckOutType == CheckOutType.None)
                     {
                         Log.Debug(Constants.LOGGING_SOURCE, "Checking out file '{0}'", file.Name);
                         file.CheckOut();


### PR DESCRIPTION
Currently FileFolderExtensions.SetFileProperties has checkoutIfRequired parameter, but it is not actually used inside the method. 

I encountered an issue when deploying files (using <pnp:Files> ) to "Pages" library and attempting to set file properties:  "The file "XXX" is checked out for editing by YYY" and found that the reason is that the code is trying to check out file twice.
I assumed, if passed checkoutIfRequired="false", SetFileProperties should not check out the file even if checkout is required by library settings.

Current change takes into account checkoutIfRequired and does not attempt to check out the file if checkoutIfRequired == false