### PR TITLE
Windows transport auth

### DIFF
--- a/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/WindowsTransport.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/WindowsTransport.cs
@@ -1,0 +1,83 @@
+﻿using OfficeDevPnP.Core.IdentityModel.WSTrustBindings;
+using System;
+using System.IdentityModel.Protocols.WSTrust;
+using System.IdentityModel.Tokens;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Security;
+
+namespace OfficeDevPnP.Core.IdentityModel.TokenProviders.ADFS
+{
+    /// <summary>
+    /// ADFS Active authentication based on NetworkCredentials. Uses the trust/13/windowstransport ADFS endpoint.
+    /// </summary>
+    public class WindowsTransport : BaseProvider
+    {
+        /// <summary>
+        /// Performs active authentication against ADFS using the trust/13/windowstransport ADFS endpoint.
+        /// </summary>
+        /// <param name="siteUrl">Url of the SharePoint site that's secured via ADFS</param>
+        /// <param name="credentials">Credentials to authenticate against endpoint.</param>
+        /// <param name="windowsTransport">Uri to the ADFS usernamemixed endpoint</param>
+        /// <param name="relyingPartyIdentifier">Identifier of the ADFS relying party that we're hitting</param>
+        /// <param name="logonTokenCacheExpirationWindow"></param>
+        /// <returns>A cookiecontainer holding the FedAuth cookie</returns>
+        public CookieContainer GetFedAuthCookie(string siteUrl, NetworkCredential credentials, Uri windowsTransport, string relyingPartyIdentifier, int logonTokenCacheExpirationWindow)
+        {
+            WindowsTransport adfsTokenProvider = new WindowsTransport();
+            var token = adfsTokenProvider.RequestToken(credentials, windowsTransport, relyingPartyIdentifier);
+            string fedAuthValue = TransformSamlTokenToFedAuth(token.TokenXml.OuterXml, siteUrl, relyingPartyIdentifier);
+
+            // Construct the cookie expiration date
+            TimeSpan lifeTime = SamlTokenlifeTime(token.TokenXml.OuterXml);
+            if (lifeTime == TimeSpan.Zero)
+            {
+                lifeTime = new TimeSpan(0, 60, 0);
+            }
+
+            int cookieLifeTime = Math.Min((lifeTime.Hours * 60 + lifeTime.Minutes), logonTokenCacheExpirationWindow);
+            DateTime expiresOn = DateTime.Now.AddMinutes(cookieLifeTime);
+
+            CookieContainer cc = null;
+
+            if (!string.IsNullOrEmpty(fedAuthValue))
+            {
+                cc = new CookieContainer();
+                Cookie samlAuth = new Cookie("FedAuth", fedAuthValue);
+                samlAuth.Expires = expiresOn;
+                samlAuth.Path = "/";
+                samlAuth.Secure = true;
+                samlAuth.HttpOnly = true;
+                Uri samlUri = new Uri(siteUrl);
+                samlAuth.Domain = samlUri.Host;
+                cc.Add(samlAuth);
+            }
+
+            return cc;
+        }
+
+        private GenericXmlSecurityToken RequestToken(NetworkCredential credentials, Uri windowsTransport, string relyingPartyIdentifier)
+        {
+            GenericXmlSecurityToken genericToken = null;
+            using (var factory = new WSTrustChannelFactory(new WindowsWSTrustBinding(), new EndpointAddress(windowsTransport)))
+            {
+                factory.TrustVersion = TrustVersion.WSTrust13;
+                // Hookup the credentials
+                factory.Credentials.Windows.ClientCredential = credentials;
+
+                var requestSecurityToken = new RequestSecurityToken
+                {
+                    RequestType = RequestTypes.Issue,
+                    AppliesTo = new EndpointReference(relyingPartyIdentifier),
+                    KeyType = KeyTypes.Bearer
+                };
+
+                IWSTrustChannelContract channel = factory.CreateChannel();
+                genericToken = channel.Issue(requestSecurityToken) as GenericXmlSecurityToken;
+                factory.Close();
+            }
+            return genericToken;
+        }
+
+    }
+}

--- a/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/WindowsTransport.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/TokenProviders/ADFS/WindowsTransport.cs
@@ -9,24 +9,12 @@ using System.ServiceModel.Security;
 namespace OfficeDevPnP.Core.IdentityModel.TokenProviders.ADFS
 {
     /// <summary>
-<<<<<<< HEAD
     /// ADFS Active authentication based on NetworkCredentials. Uses the trust/13/windowstransport ADFS endpoint.
-=======
-    /// ADFS Active authentication based on username + password. Uses the trust/13/usernamemixed ADFS endpoint.
->>>>>>> 1ee38d007d59c2c2ea40148a256e9f7a71b82103
     /// </summary>
     public class WindowsTransport : BaseProvider
     {
         /// <summary>
-<<<<<<< HEAD
         /// Performs active authentication against ADFS using the trust/13/windowstransport ADFS endpoint.
-=======
-<<<<<<< HEAD
-        /// Performs active authentication against ADFS using the trust/13/windowstransport ADFS endpoint.
-=======
-        /// Performs active authentication against ADFS using the trust/13/usernamemixed ADFS endpoint.
->>>>>>> 1ee38d007d59c2c2ea40148a256e9f7a71b82103
->>>>>>> ff441d089b76d40ca817ff1f4b988685228df519
         /// </summary>
         /// <param name="siteUrl">Url of the SharePoint site that's secured via ADFS</param>
         /// <param name="credentials">Credentials to authenticate against endpoint.</param>

--- a/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/UserNameWSTrustBinding.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/UserNameWSTrustBinding.cs
@@ -1,6 +1,4 @@
-﻿/* Based on reflectored code coming from Microsoft.IdentityModel.Protocols.WSTrust.Bindings.UserNameWSTrustBinding class */
-
-using System;
+﻿using System;
 using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;

--- a/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/WindowsWSTrustBinding.cs
+++ b/Core/OfficeDevPnP.Core/IdentityModel/WSTrustBindings/WindowsWSTrustBinding.cs
@@ -1,0 +1,25 @@
+﻿/* Based on reflectored code coming from Microsoft.IdentityModel.Protocols.WSTrust.Bindings.UserNameWSTrustBinding class */
+
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace OfficeDevPnP.Core.IdentityModel.WSTrustBindings
+{
+    public class WindowsWSTrustBinding : WSTrustBinding
+    {
+        // Methods
+        public WindowsWSTrustBinding() : base(SecurityMode.Transport) { }
+
+        protected override void ApplyTransportSecurity(HttpTransportBindingElement transport) {
+            transport.AuthenticationScheme = AuthenticationSchemes.Negotiate;
+        }
+
+
+        protected override SecurityBindingElement CreateSecurityBindingElement()
+        {
+            return SecurityBindingElement.CreateKerberosOverTransportBindingElement();
+        }
+   }
+}

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -469,6 +469,8 @@
     <Compile Include="Framework\TimerJobs\TimerJob.cs" />
     <Compile Include="Framework\TimerJobs\TimerJobRun.cs" />
     <Compile Include="Framework\TimerJobs\TimerJobRunEventArgs.cs" />
+    <Compile Include="IdentityModel\TokenProviders\ADFS\WindowsTransport.cs" />
+    <Compile Include="IdentityModel\WSTrustBindings\WindowsWSTrustBinding.cs" />
     <Compile Include="Utilities\FileTokenCache.cs" />
     <Compile Include="Framework\TimerJobs\Utilities\SiteEnumeration.cs" />
     <Compile Include="IdentityModel\TokenProviders\ADFS\BaseProvider.cs" />


### PR DESCRIPTION
Added ADFS authentication against windowstransport, thus allows using Windows Integrated Authentication (Negotiate) by passing credentials from CredentialCache. 

Probably the codebase could be made more DRY by moving something from ADFS classes UsernameMixed and WindowsTransport to BaseProvider.