### PR TITLE
EnsureProperty helper method

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -280,6 +280,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="TestCommon.cs" />
+    <Compile Include="Utilities\UtilityTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OfficeDevPnP.Core\OfficeDevPnP.Core.csproj">

--- a/Core/OfficeDevPnP.Core.Tests/Utilities/UtilityTest.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Utilities/UtilityTest.cs
@@ -145,5 +145,30 @@ namespace OfficeDevPnP.Core.Tests.Utilities
 				Assert.IsNotNull(clientContext.Web.RootFolder.ServerRelativeUrl);
 			}
 		}
+
+		[TestMethod]
+		public void EnsureMultiplePropertiesTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					clientContext.Web.EnsureProperties(w => w.Fields, w => w.ServerRelativeUrl);
+
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsNull(expectedException);
+				Assert.IsTrue(clientContext.Web.IsObjectPropertyInstantiated(w => w.Fields));
+				Assert.IsTrue(clientContext.Web.IsPropertyAvailable(w => w.ServerRelativeUrl));
+			}
+		}
 	}
 }

--- a/Core/OfficeDevPnP.Core.Tests/Utilities/UtilityTest.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Utilities/UtilityTest.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Linq;
+using Microsoft.SharePoint.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OfficeDevPnP.Core.Utilities;
+
+namespace OfficeDevPnP.Core.Tests.Utilities
+{
+	[TestClass]
+	public class UtilityTest
+	{
+		[TestMethod]
+		public void NotLoadedPropertyExceptionTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var webUrl = clientContext.Web.ServerRelativeUrl;
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsTrue(expectedException is PropertyOrFieldNotInitializedException);
+			}
+		}
+
+		[TestMethod]
+		public void EnsurePropertyTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var serverRelativeUrl = clientContext.Web.EnsureProperty(w => w.ServerRelativeUrl);
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsNull(expectedException);
+				Assert.IsTrue(clientContext.Web.IsPropertyAvailable(w => w.ServerRelativeUrl));
+			}
+		}
+
+		[TestMethod]
+		public void NotLoadedCollectionExceptionTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var webFields = clientContext.Web.Fields.ToList();
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsTrue(expectedException is CollectionNotInitializedException);
+			}
+		}
+		
+		[TestMethod]
+		public void EnsureCollectionPropertyTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var webFields = clientContext.Web.EnsureProperty(w => w.Fields).ToList();
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsNull(expectedException);
+				Assert.IsTrue(clientContext.Web.IsObjectPropertyInstantiated(w => w.Fields));
+			}
+		}
+
+		[TestMethod]
+		public void NotLoadedComplexPropertyExceptionTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var rootFolderUrl = clientContext.Web.RootFolder.ServerRelativeUrl;
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsTrue(expectedException is PropertyOrFieldNotInitializedException);
+			}
+		}
+
+		[TestMethod]
+		public void EnsureComplexPropertyTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				//Arrange
+				Exception expectedException = null;
+				try
+				{
+					//Act
+					var rootFolderUrl = clientContext.Web.EnsureProperty(f => f.RootFolder);
+					
+				}
+				catch (Exception ex)
+				{
+					expectedException = ex;
+				}
+
+				//Assert
+				Assert.IsNull(expectedException);
+				Assert.IsTrue(clientContext.Web.IsObjectPropertyInstantiated(w => w.RootFolder));
+				Assert.IsNotNull(clientContext.Web.RootFolder.ServerRelativeUrl);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Now instead of writing something like this: 

    if (!web.IsPropertyAvailable("ServerRelativeUrl"))
    {
    	clientContext.Load(web, w => w.ServerRelativeUrl);
    	clientContext.ExecuteQueryRetry();
    }
    var serverRelativeUrl = web.ServerRelativeUrl;

you can do just 

    string serverRelativeUrl = web.EnsureProperty(w => w.ServerRelativeUrl);

Another examples: 

    bool hasUniquePermisions = web.EnsureProperty(w => w.HasUniqueRoleAssignments);

Or 

    FieldCollection fields = clientContext.Web.EnsureProperty(w => w.Fields);

Or for multiple properties: 

    clientContext.Web.EnsureProperties(w => w.Fields, w => w.ServerRelativeUrl);    

Only one level of property depth supported. 