### PR TITLE
Implemented extraction cleanup handling for new object handlers

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/RoleDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/RoleDefinition.cs
@@ -21,7 +21,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
 
         public RoleDefinition(IEnumerable<Microsoft.SharePoint.Client.PermissionKind> permissions)
         {
-            if(permissions != null)
+            if (permissions != null)
             {
                 this._permissions.AddRange(permissions);
             }
@@ -59,7 +59,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
             return (String.Format("{0}|{1}|{2}|",
                 this.Permissions.GetHashCode(),
                 this.Name.GetHashCode(),
-                this.Description.GetHashCode()
+                this.Description.GetHashCode(),
+                this.Permissions.Aggregate(0, (acc, next) => acc += next.GetHashCode())
             ).GetHashCode());
         }
 
@@ -74,9 +75,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
 
         public bool Equals(RoleDefinition other)
         {
-            return (this.Permissions.DeepEquals(other.Permissions) &&
-                this.Name == other.Name &&
-                this.Description == other.Description );
+            return (this.Name == other.Name &&
+                this.Description == other.Description &&
+                this.Permissions.DeepEquals(other.Permissions));
         }
 
         #endregion

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRegionalSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRegionalSettings.cs
@@ -42,6 +42,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 settings.WorkDayStartHour = (WorkHour)web.RegionalSettings.WorkDayStartHour;
 
                 template.RegionalSettings = settings;
+
+                // If a base template is specified then use that one to "cleanup" the generated template model
+                if (creationInfo.BaseTemplate != null)
+                {
+                    template = CleanupEntities(template, creationInfo.BaseTemplate);
+
+                }
             }
             return template;
         }
@@ -123,6 +130,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return parser;
+        }
+
+        private ProvisioningTemplate CleanupEntities(ProvisioningTemplate template, ProvisioningTemplate baseTemplate)
+        {
+            if (template.RegionalSettings != null && baseTemplate.RegionalSettings != null && baseTemplate.RegionalSettings.Equals(template.RegionalSettings))
+            {
+                template.RegionalSettings = null;
+            }
+            return template;
         }
 
         public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -513,6 +513,42 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
             }
 
+            foreach (var baseSiteGroup in baseTemplate.Security.SiteGroups)
+            {
+                var templateSiteGroup = template.Security.SiteGroups.FirstOrDefault(sg => sg.Title == baseSiteGroup.Title);
+                if (templateSiteGroup != null)
+                {
+                    if (templateSiteGroup.Equals(baseSiteGroup))
+                    {
+                        template.Security.SiteGroups.Remove(templateSiteGroup);
+                    }
+                }
+            }
+
+            foreach (var baseRoleDef in baseTemplate.Security.SiteSecurityPermissions.RoleDefinitions)
+            {
+                var templateRoleDef = template.Security.SiteSecurityPermissions.RoleDefinitions.FirstOrDefault(rd => rd.Name == baseRoleDef.Name);
+                if (templateRoleDef != null)
+                {
+                    if (templateRoleDef.Equals(baseRoleDef))
+                    {
+                        template.Security.SiteSecurityPermissions.RoleDefinitions.Remove(templateRoleDef);
+                    }
+                }
+            }
+
+            foreach (var baseRoleAssignment in baseTemplate.Security.SiteSecurityPermissions.RoleAssignments)
+            {
+                var templateRoleAssignments = template.Security.SiteSecurityPermissions.RoleAssignments.Where(ra => ra.Principal == baseRoleAssignment.Principal).ToList();
+                foreach (var templateRoleAssignment in templateRoleAssignments)
+                {
+                    if (templateRoleAssignment.Equals(baseRoleAssignment))
+                    {
+                        template.Security.SiteSecurityPermissions.RoleAssignments.Remove(templateRoleAssignment);
+                    }
+                }
+            }
+
             return template;
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSupportedUILanguages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSupportedUILanguages.cs
@@ -31,6 +31,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
 
             }
+
             return template;
         }
 
@@ -71,7 +72,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             return parser;
         }
-
         public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
             return true;


### PR DESCRIPTION
Added extraction cleanup handling for new object handlers
Write warning that content types are not included when exporting a template from a subweb if lists in subwebs refers to content types.