### PR TITLE
Updated references from EnsureProperty to EnsureProperties.

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				//Arrange
 				var subSite = CreateTestTeamSubSite(clientContext.Web);
 
-                subSite.EnsureProperty(s => s.HasUniqueRoleAssignments);
+                subSite.EnsureProperties(s => s.HasUniqueRoleAssignments);
 				
 				if (!subSite.HasUniqueRoleAssignments)
 				{
@@ -201,7 +201,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				//Arrange
 				var list = clientContext.Web.CreateList(ListTemplateType.GenericList, GetRandomString(), false);
 
-                list.EnsureProperty(l => l.HasUniqueRoleAssignments);
+                list.EnsureProperties(l => l.HasUniqueRoleAssignments);
                 
 				if (!list.HasUniqueRoleAssignments)
 				{
@@ -237,7 +237,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				clientContext.Load(item);
 				clientContext.ExecuteQueryRetry();
 
-                item.EnsureProperty(i => i.HasUniqueRoleAssignments);
+                item.EnsureProperties(i => i.HasUniqueRoleAssignments);
 				
 				if (!item.HasUniqueRoleAssignments)
 				{
@@ -269,7 +269,7 @@ namespace Microsoft.SharePoint.Client.Tests
 				var subSite = CreateTestTeamSubSite(clientContext.Web);
 
 
-                subSite.EnsureProperty(s => s.HasUniqueRoleAssignments);
+                subSite.EnsureProperties(s => s.HasUniqueRoleAssignments);
 				
 				if (!subSite.HasUniqueRoleAssignments)
 				{

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
@@ -29,7 +29,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
                 
                 var file = ctx.Web.GetFileByServerRelativeUrl(UrlUtility.Combine(ctx.Web.ServerRelativeUrl, "test/" + fileName));
                 ctx.Load(file, f => f.Exists);
@@ -65,7 +65,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 new ObjectFiles().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
 
 
-                ctx.Web.EnsureProperty(w => w.ServerRelativeUrl);
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
                 
                 var file = ctx.Web.GetFileByServerRelativeUrl(
                     UrlUtility.Combine(ctx.Web.ServerRelativeUrl,

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.SharePoint.Client
             var backgroundUrl = default(string);
             var masterUrl = default(string);
 
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             if (!string.IsNullOrEmpty(paletteFileName))
             {
@@ -106,7 +106,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="replaceContent">Replace composed look if it already exists (default true)</param>
         public static void CreateComposedLookByUrl(this Web web, string lookName, string paletteServerRelativeUrl, string fontServerRelativeUrl, string backgroundServerRelativeUrl, string masterServerRelativeUrl, int displayOrder = 1, bool replaceContent = true)
         {
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             var composedLooksList = web.GetCatalog((int)ListTemplateType.DesignCatalog);
 
@@ -1214,7 +1214,7 @@ namespace Microsoft.SharePoint.Client
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentNullException("url");
 
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
 
             string newUrl = url.Substring(web.ServerRelativeUrl.Length);
             if (newUrl.Length > 0 && newUrl[0] == '/')

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FeatureExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FeatureExtensions.cs
@@ -92,8 +92,8 @@ namespace Microsoft.SharePoint.Client
             features.Context.ExecuteQueryRetry();
 
             Feature iprFeature = features.GetById(featureID);
-            iprFeature.EnsureProperty(f => f.DefinitionId);
-            
+            iprFeature.EnsureProperties(f => f.DefinitionId);
+
             if (iprFeature != null && iprFeature.IsPropertyAvailable("DefinitionId") && !iprFeature.ServerObjectIsNull.Value && iprFeature.DefinitionId.Equals(featureID))
             {
                 featureIsActive = true;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -224,8 +224,8 @@ namespace Microsoft.SharePoint.Client
         /// <returns>The folder structure</returns>
         public static Folder EnsureFolder(this Web web, Folder parentFolder, string folderPath)
         {
-            web.EnsureProperty(w => w.ServerRelativeUrl);
-            parentFolder.EnsureProperty(f => f.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
+            parentFolder.EnsureProperties(f => f.ServerRelativeUrl);
 
             var parentWebRelativeUrl = parentFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length);
             var webRelativeUrl = parentWebRelativeUrl + (parentWebRelativeUrl.EndsWith("/") ? "" : "/") + folderPath;
@@ -795,7 +795,7 @@ namespace Microsoft.SharePoint.Client
 
             try
             {
-                folder.EnsureProperty(f => f.ServerRelativeUrl);
+                folder.EnsureProperties(f => f.ServerRelativeUrl);
                 
                 var fileServerRelativeUrl = UrlUtility.Combine(folder.ServerRelativeUrl, fileName);
                 var context = folder.Context as ClientContext;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.SharePoint.Client
 
             Guid returnGuid = Guid.Empty;
 
-            web.EnsureProperty(w => w.Url);
+            web.EnsureProperties(w => w.Url);
 
             returnGuid = new Guid(TokenHelper.GetRealmFromTargetUrl(new Uri(web.Url)));
 

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -1912,7 +1912,7 @@ namespace Microsoft.SharePoint.Client
 			if (termSet == default(TermSet))
 				throw new ArgumentException("Bound TaxonomyItem must be either a TermSet or a Term");
 
-            termSet.EnsureProperty(ts => ts.TermStore);
+            termSet.EnsureProperties(ts => ts.TermStore);
             
 			// set the SSP ID and Term Set ID on the taxonomy field
 			var taxField = clientContext.CastTo<TaxonomyField>(field);

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.SharePoint.Client
             }
 
             var deleted = false;
-            parentWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            parentWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
             var serverRelativeUrl = UrlUtility.Combine(parentWeb.ServerRelativeUrl, leafUrl);
             var webs = parentWeb.Webs;
@@ -194,7 +194,7 @@ namespace Microsoft.SharePoint.Client
                 throw new ArgumentException("The argument must be a single web URL and cannot contain path characters.", "leafUrl");
             }
 
-            parentWeb.EnsureProperty(w => w.ServerRelativeUrl);
+            parentWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
             var serverRelativeUrl = UrlUtility.Combine(parentWeb.ServerRelativeUrl, leafUrl);
             var webs = parentWeb.Webs;
@@ -1014,7 +1014,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="descriptionResource">Localized Description string</param>
         public static void SetLocalizationLabels(this Web web, string cultureName, string titleResource, string descriptionResource)
         {
-            web.EnsureProperty(w => w.TitleResource);
+            web.EnsureProperties(w => w.TitleResource);
 
             // Set translations for the culture
             web.TitleResource.SetValueForUICulture(cultureName, titleResource);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -294,7 +294,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                         }
                     }
 
-                    spFolder.EnsureProperty(f => f.ServerRelativeUrl);
+                    spFolder.EnsureProperties(f => f.ServerRelativeUrl);
 
                     var fileServerRelativeUrl = UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
                     File file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
@@ -370,7 +370,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                         }
                     }
 
-                    spFolder.EnsureProperty(f => f.ServerRelativeUrl);
+                    spFolder.EnsureProperties(f => f.ServerRelativeUrl);
                     
                     var fileServerRelativeUrl = UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
                     file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -21,7 +21,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 var context = web.Context as ClientContext;
 
-                web.EnsureProperty(w => w.ServerRelativeUrl);
+                web.EnsureProperties(w => w.ServerRelativeUrl);
 
                 foreach (var file in template.Files)
                 {
@@ -80,7 +80,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         if (file.WebParts != null && file.WebParts.Any())
                         {
-                            targetFile.EnsureProperty(f => f.ServerRelativeUrl);
+                            targetFile.EnsureProperties(f => f.ServerRelativeUrl);
                             
                             var existingWebParts = web.GetWebParts(targetFile.ServerRelativeUrl);
                             foreach (var webpart in file.WebParts)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -29,7 +29,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     var rootWeb = (web.Context as ClientContext).Site.RootWeb;
 
-                    web.EnsureProperty(w => w.ServerRelativeUrl);
+                    web.EnsureProperties(w => w.ServerRelativeUrl);
 
                     web.Context.Load(web.Lists, lc => lc.IncludeWithDefaultProperties(l => l.RootFolder.ServerRelativeUrl));
                     web.Context.ExecuteQueryRetry();

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -24,7 +24,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     var rootWeb = (web.Context as ClientContext).Site.RootWeb;
 
-                    web.EnsureProperty(w => w.ServerRelativeUrl);
+                    web.EnsureProperties(w => w.ServerRelativeUrl);
                     
                     web.Context.Load(web.Lists, lc => lc.IncludeWithDefaultProperties(l => l.RootFolder.ServerRelativeUrl));
                     web.Context.ExecuteQueryRetry();

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -24,7 +24,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 var context = web.Context as ClientContext;
 
-                web.EnsureProperty(w => w.ServerRelativeUrl);
+                web.EnsureProperties(w => w.ServerRelativeUrl);
                 
                 foreach (var page in template.Pages)
                 {
@@ -89,7 +89,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     if (page.WelcomePage)
                     {
-                        web.EnsureProperty(w => w.RootFolder);
+                        web.EnsureProperties(w => w.RootFolder);
                         
                         var rootFolderRelativeUrl = url.Substring(web.RootFolder.ServerRelativeUrl.Length);
                         web.SetHomePage(rootFolderRelativeUrl);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -37,7 +37,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public TokenParser(Web web, ProvisioningTemplate template)
         {
-            web.EnsureProperty(w => w.ServerRelativeUrl);
+            web.EnsureProperties(w => w.ServerRelativeUrl);
             
             _web = web;
 


### PR DESCRIPTION
There is an issue with EnsureProperty not accepting properties of type Guid. (Like DefinitionId, Id, etc.). I updated references to those methods where appropriate with a call to EnsureProperties.