### PR TITLE
Make token parser available for provisioning extensions

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
@@ -45,8 +45,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
                     provider.Assembly,
                     provider.Type);
 
-                var _instance = (IProvisioningExtensibilityProvider)Activator.CreateInstance(provider.Assembly, provider.Type).Unwrap();
-                _instance.ProcessRequest(ctx, template, parser, provider.Configuration);
+                var _instance = Activator.CreateInstance(provider.Assembly, provider.Type).Unwrap();
+				if (_instance is IProvisioningExtensibilityProvider2)
+				{
+					((IProvisioningExtensibilityProvider2)_instance).ProcessRequest(ctx, template, parser, provider.Configuration);
+				}
+				else
+				{
+					((IProvisioningExtensibilityProvider)_instance).ProcessRequest(ctx, template, provider.Configuration);
+				}
 
                 Log.Info(_loggingSource,
                     CoreResources.Provisioning_Extensibility_Pipeline_Success,

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
@@ -2,6 +2,7 @@
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Diagnostics;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
 {
@@ -17,10 +18,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
         /// <param name="ctx">Authenticated ClientContext that is passed to teh custom provider.</param>
         /// <param name="provider">A custom Extensibility Provisioning Provider</param>
         /// <param name="template">ProvisioningTemplate that is passed to the custom provider</param>
-        /// <exception cref="ExtensiblityPipelineException"></exception>
+		/// <param name="parser">Instance of Token Parser that is passed to the custom provider</param>
+		/// <exception cref="ExtensiblityPipelineException"></exception>
         /// <exception cref="ArgumentException">Provider.Assembly or Provider.Type is NullOrWhiteSpace></exception>
         /// <exception cref="ArgumentNullException">ClientContext is Null></exception>
-        public void ExecuteExtensibilityCallOut(ClientContext ctx, Provider provider, ProvisioningTemplate template)
+        public void ExecuteExtensibilityCallOut(ClientContext ctx, Provider provider, ProvisioningTemplate template, TokenParser parser)
         {
             var _loggingSource = "OfficeDevPnP.Core.Framework.Provisioning.Extensibility.ExtensibilityManager.ExecuteCallout";
 
@@ -44,7 +46,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
                     provider.Type);
 
                 var _instance = (IProvisioningExtensibilityProvider)Activator.CreateInstance(provider.Assembly, provider.Type).Unwrap();
-                _instance.ProcessRequest(ctx, template, provider.Configuration);
+                _instance.ProcessRequest(ctx, template, parser, provider.Configuration);
 
                 Log.Info(_loggingSource,
                     CoreResources.Provisioning_Extensibility_Pipeline_Success,

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/IProvisioningExtensibilityProvider.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/IProvisioningExtensibilityProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
 {
@@ -13,7 +14,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="template"></param>
-        /// <param name="configurationData"></param>
-        void ProcessRequest(ClientContext ctx, ProvisioningTemplate template, string configurationData);
+		/// <param name="parser"></param>
+		/// <param name="configurationData"></param>
+        void ProcessRequest(ClientContext ctx, ProvisioningTemplate template, TokenParser parser, string configurationData);
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/IProvisioningExtensibilityProvider2.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/IProvisioningExtensibilityProvider2.cs
@@ -1,20 +1,20 @@
 ﻿using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
 {
     /// <summary>
     /// Defines a interface that accepts requests from the provisioning processing component
     /// </summary>
-    public interface IProvisioningExtensibilityProvider
+    public interface IProvisioningExtensibilityProvider2
     {
         /// <summary>
         /// Defines a interface that accepts requests from the provisioning processing component
         /// </summary>
         /// <param name="ctx"></param>
         /// <param name="template"></param>
-		/// <param name="parser"></param>
-		/// <param name="configurationData"></param>
-        void ProcessRequest(ClientContext ctx, ProvisioningTemplate template, string configurationData);
+        /// <param name="configurationData"></param>
+        void ProcessRequest(ClientContext ctx, ProvisioningTemplate template, TokenParser parser, string configurationData);
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
@@ -32,7 +32,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         try
                         {
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ExtensibilityProviders_Calling_extensibility_callout__0_, provider.Assembly);
-                            _extManager.ExecuteExtensibilityCallOut(context, provider, template);
+                            _extManager.ExecuteExtensibilityCallOut(context, provider, template, parser);
                         }
                         catch (Exception ex)
                         {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -4,7 +4,7 @@ using Microsoft.SharePoint.Client;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
-    internal abstract class TokenDefinition
+    public abstract class TokenDefinition
     {
         protected string CacheValue;
         private readonly string[] _tokens;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -8,7 +8,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    internal class TokenParser
+    public class TokenParser
     {
         public Web _web;
 

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Framework\Provisioning\Extensibility\ExtensibilityManager.cs" />
     <Compile Include="Framework\Provisioning\Extensibility\ExtensiblityPipelineException.cs" />
     <Compile Include="Framework\Provisioning\Extensibility\IProvisioningExtensibilityProvider.cs" />
+    <Compile Include="Framework\Provisioning\Extensibility\IProvisioningExtensibilityProvider2.cs" />
     <Compile Include="Framework\Provisioning\Model\AddIn.cs" />
     <Compile Include="Framework\Provisioning\Model\AuditSettings.cs" />
     <Compile Include="Framework\Provisioning\Model\AvailableWebTemplate.cs" />


### PR DESCRIPTION
Previously ToParsedString extension was available for use in custom extensibility providers. Since TokenParser is not static any more it would be nice to have an instance of that in extensibility provider to parse tokens in custom configuration data.