### PR TITLE
some provisioning engine fixes

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
@@ -92,10 +93,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
 
         private static string ReplaceGroupTokens(Web web, string loginName)
         {
-            loginName = loginName.Replace(web.AssociatedOwnerGroup.Title, "{associatedownergroup}");
-            loginName = loginName.Replace(web.AssociatedMemberGroup.Title, "{associatedmembergroup}");
-            loginName = loginName.Replace(web.AssociatedVisitorGroup.Title, "{associatedvisitorgroup}");
-
+			Regex regex = new Regex("{associated(owner|member|visitor)group}");
+			if(regex.IsMatch(loginName))
+			{
+				loginName = loginName.Replace(web.AssociatedOwnerGroup.Title, "{associatedownergroup}");
+				loginName = loginName.Replace(web.AssociatedMemberGroup.Title, "{associatedmembergroup}");
+				loginName = loginName.Replace(web.AssociatedVisitorGroup.Title, "{associatedvisitorgroup}");
+			}
             return loginName;
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -599,7 +599,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         existingList.EnableVersioning = templateList.EnableVersioning;
                         isDirty = true;
                     }
-                    if (existingList.MajorVersionLimit != templateList.MaxVersionLimit)
+                    if (existingList.IsObjectPropertyInstantiated("MajorVersionLimit") && existingList.MajorVersionLimit != templateList.MaxVersionLimit)
                     {
                         existingList.MajorVersionLimit = templateList.MaxVersionLimit;
                         isDirty = true;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -298,8 +298,15 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     // Find the site collection termgroup, if any
                     TaxonomySession session = TaxonomySession.GetTaxonomySession(web.Context);
                     var termStore = session.GetDefaultSiteCollectionTermStore();
-                    web.Context.Load(termStore, t => t.Id, t => t.DefaultLanguage);
-                    web.Context.ExecuteQueryRetry();
+					web.Context.Load(termStore, t => t.Id, t => t.DefaultLanguage);
+					web.Context.ExecuteQueryRetry();
+
+					if (termStore.ServerObjectIsNull.Value)
+					{
+						termStore = session.GetDefaultKeywordsTermStore();
+						web.Context.Load(termStore, t => t.Id, t => t.DefaultLanguage);
+						web.Context.ExecuteQueryRetry();
+					}
 
                     List<TermGroup> termGroups = new List<TermGroup>();
                     if (creationInfo.IncludeAllTermGroups)


### PR DESCRIPTION
Some early versions of CSOM for SP2013 on-premises does not support MajorVersionLimit, so it breaks provisioning if versioning enabled,