### PR TITLE
Proposal for Issue #44

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Entities;
@@ -22,20 +23,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var context = web.Context as ClientContext;
 
                 web.EnsureProperties(w => w.ServerRelativeUrl);
+                var rootWeb = context.Site.RootWeb;
+                rootWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
                 foreach (var file in template.Files)
                 {
 
                     var folderName = parser.ParseString(file.Folder);
-
-                    if (folderName.ToLower().StartsWith((web.ServerRelativeUrl.ToLower())))
+                    var isRootWebFolder = parser.ContainsRootWebToken(file.Folder);
+                    var targetWeb = isRootWebFolder ? rootWeb : web;
+                    if (folderName.ToLower().StartsWith((targetWeb.ServerRelativeUrl.ToLower())))
                     {
-                        folderName = folderName.Substring(web.ServerRelativeUrl.Length);
+                        folderName = folderName.Substring(targetWeb.ServerRelativeUrl.Length);
                     }
 
-
-                    var folder = web.EnsureFolderPath(folderName);
-
+                    var folder = targetWeb.EnsureFolderPath(folderName);
+                    
                     File targetFile = null;
 
                     var checkedOut = false;
@@ -56,7 +59,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         else
                         {
-                            checkedOut = CheckOutIfNeeded(web, targetFile);
+                            checkedOut = CheckOutIfNeeded(targetWeb, targetFile);
                         }
                     }
                     else
@@ -67,7 +70,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             targetFile = folder.UploadFile(template.Connector.GetFilenamePart(file.Src), stream, file.Overwrite);
                         }
 
-                        checkedOut = CheckOutIfNeeded(web, targetFile);
+                        checkedOut = CheckOutIfNeeded(targetWeb, targetFile);
                     }
 
                     if (targetFile != null)
@@ -95,7 +98,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     wpEntity.WebPartZone = webpart.Zone;
                                     wpEntity.WebPartIndex = (int)webpart.Order;
 
-                                    web.AddWebPartToWebPartPage(targetFile.ServerRelativeUrl, wpEntity);
+                                    targetWeb.AddWebPartToWebPartPage(targetFile.ServerRelativeUrl, wpEntity);
                                 }
                             }
                         }
@@ -103,7 +106,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         if (checkedOut)
                         {
                             targetFile.CheckIn("", CheckinType.MajorCheckIn);
-                            web.Context.ExecuteQueryRetry();
+                            targetWeb.Context.ExecuteQueryRetry();
                         }
 
                         if (file.Security != null)

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
@@ -23,5 +23,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
             }
             return CacheValue;
         }
+
+        public override bool IsRootWebToken
+        {
+            get { return true; }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -49,5 +49,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         {
             this.CacheValue = null;
         }
+
+        /// <summary>
+        /// Determines if this token automatically corresponds to a Root Web URL
+        /// </summary>
+        public virtual bool IsRootWebToken
+        {
+            get { return false; }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -184,5 +184,49 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return input;
         }
 
+        /// <summary>
+        /// Determines whether the specified <paramref name="input"/> contains a token that will be converted into a URL that belongs to the Root Web
+        /// </summary>
+        /// <param name="input">The input string that contains tokens that should be converted.</param>
+        /// <param name="tokensToSkip">Tokens that should be skipped</param>
+        /// <returns><c>true</c> if the input string contains tokens that will be converted to a URL that belongs to the Root Web</returns>
+        public bool ContainsRootWebToken(string input, params string[] tokensToSkip)
+        {
+            if (!string.IsNullOrEmpty(input))
+            {
+                foreach (var token in _tokens)
+                {
+                    if (tokensToSkip != null)
+                    {
+                        if (token.GetTokens().Except(tokensToSkip, StringComparer.InvariantCultureIgnoreCase).Any())
+                        {
+                            foreach (var filteredToken in token.GetTokens().Except(tokensToSkip, StringComparer.InvariantCultureIgnoreCase))
+                            {
+                                var regex = token.GetRegexForToken(filteredToken);
+                                if (regex.IsMatch(input))
+                                {
+                                    if (token.IsRootWebToken)
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var regex in token.GetRegex().Where(regex => regex.IsMatch(input)))
+                        {
+                            if (token.IsRootWebToken)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Some items have to be always located in the RootWeb even if the actions occur on a subsite. One example for this are items that are located in the "ThemeCatalog" which is always located in the RootWeb. Currently, the provisioning engine tries to create those files in the subsite where all other actions take place. Unfortunately, this results in an error.

This pull request is a proposal to fix this issue by dynamically changing the target of an action to the local subsite or the root web based on the token. The token gets a new property that determines if it is a token that must point to the RootWeb. The Parser gets a new function that reads this property and the provisioning engine changes the target accordingly.

See also Issue #44.