### PR TITLE
BugFix for TimerJob framework to run On-Premises using AppOnly authen…

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -82,6 +82,22 @@ namespace OfficeDevPnP.Core
             return clientContext;
         }
 
+
+        /// <summary>
+        /// Returns an app only ClientContext object for On-Premises
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <param name="realm">Realm of the environment (tenant) that requests the ClientContext object</param>
+        /// <param name="appId">Application ID which is requesting the ClientContext object</param>        
+        /// <returns>ClientContext to be used by CSOM code</returns>
+        public ClientContext GetOnPremisesAppOnlyAuthenticatedContext(string siteUrl, string realm, string appId)
+        {
+            Uri siteUri = new Uri(siteUrl);
+            string appOnlyAccessToken = Utilities.TokenHelper.GetS2SAccessTokenWithWindowsIdentity(siteUri, null);
+            ClientContext clientContext = Utilities.TokenHelper.GetClientContextWithAccessToken(siteUrl, appOnlyAccessToken);
+            return clientContext;
+        }
+
         /// <summary>
         /// Returns a SharePoint on-premises / SharePoint Online Dedicated ClientContext object
         /// </summary>

--- a/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
+++ b/Core/OfficeDevPnP.Core/Framework/TimerJobs/TimerJob.cs
@@ -1360,8 +1360,8 @@ namespace OfficeDevPnP.Core.Framework.TimerJobs
                     return GetAuthenticationManager(site).GetNetworkCredentialAuthenticatedContext(site, username, password, domain);
                 }
                 else if (AuthenticationType == AuthenticationType.AppOnly)
-                {
-                    return GetAuthenticationManager(site).GetAppOnlyAuthenticatedContext(site, this.realm, this.clientId, this.clientSecret);
+                {                    
+                    return GetAuthenticationManager(site).GetOnPremisesAppOnlyAuthenticatedContext(site, this.realm, this.clientId);
                 }
             }
             else


### PR DESCRIPTION
The existing Remote timer job framework does not work for On-Premises AppOnly authentication scenario (without entering Network credentials). This bugfix is for fixing this scenario.