### PR TITLE
Making sure IDs are loaded for all FieldLinks in a ContentType with EnsureProperties

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -739,6 +739,10 @@ namespace Microsoft.SharePoint.Client
         public static void AddFieldToContentType(this Web web, ContentType contentType, Field field, bool required = false, bool hidden = false)
         {
             contentType.EnsureProperties(c => c.Id, c => c.FieldLinks, c => c.SchemaXml);
+            foreach(FieldLink fieldLink in contentType.FieldLinks)
+            {
+                fieldLink.EnsureProperties(fl => fl.Id);
+            }
             field.EnsureProperties(f => f.Id, f => f.SchemaXml);
 
             Log.Info(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_AddField0ToContentType1, field.Id, contentType.Id);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -102,8 +102,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         if (checkedOut)
                         {
-                            targetFile.CheckIn("", CheckinType.MajorCheckIn);
-                            web.Context.ExecuteQueryRetry();
+                            try {
+                                targetFile.CheckIn("", CheckinType.MajorCheckIn);
+                                web.Context.ExecuteQueryRetry();
+                            } catch(ServerException e)
+                            {
+                                // TODO - File could not be checked in
+                            }
                         }
 
                         // Don't set security when nothing is defined. This otherwise breaks on files set outside of a list

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -130,8 +130,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (targetFile.CheckOutType == CheckOutType.None)
                 {
                     targetFile.CheckOut();
-                }
-                checkedOut = true;
+                    checkedOut = true;
+                }    
             }
             catch (ServerException ex)
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -617,11 +617,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         existingList.EnableVersioning = templateList.EnableVersioning;
                         isDirty = true;
                     }
+#if !CLIENTSDKV15
                     if (existingList.IsObjectPropertyInstantiated("MajorVersionLimit") && existingList.MajorVersionLimit != templateList.MaxVersionLimit)
                     {
                         existingList.MajorVersionLimit = templateList.MaxVersionLimit;
                         isDirty = true;
                     }
+#endif
                     if (existingList.BaseTemplate == (int)ListTemplateType.DocumentLibrary)
                     {
                         // Only supported on Document Libraries
@@ -747,7 +749,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             createdList.EnableVersioning = list.EnableVersioning;
             if (list.EnableVersioning)
             {
+#if !CLIENTSDKV15
                 createdList.MajorVersionLimit = list.MaxVersionLimit;
+#endif
 
                 if (createdList.BaseTemplate == (int)ListTemplateType.DocumentLibrary)
                 {


### PR DESCRIPTION
I created a issue earlier today (https://github.com/OfficeDev/PnP-Sites-Core/issues/91) related to Content Types and Fields. I got a error when adding certain fields to a Content Type. The ID of the field was not loaded properly.

I went through and debugged the ContentType-handler and found that sometimes the fields wasn't loaded properly.

With this pull request I'm making sure IDs are loaded for all FieldLinks in a ContentType with the override EnsureProperties().