### PR TITLE
Getavailabepagelayoutfix

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
@@ -51,7 +51,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             var defaultLayoutXml = web.GetPropertyBagValueString(DEFAULTPAGELAYOUT, null);
 
             var defaultPageLayoutUrl = string.Empty;
-            if (defaultLayoutXml != null)
+            if (defaultLayoutXml != null && defaultLayoutXml != "__inherit")
             {
                 defaultPageLayoutUrl = XElement.Parse(defaultLayoutXml).Attribute("url").Value;
             }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPublishing.cs
@@ -51,7 +51,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             var defaultLayoutXml = web.GetPropertyBagValueString(DEFAULTPAGELAYOUT, null);
 
             var defaultPageLayoutUrl = string.Empty;
-            if (defaultLayoutXml != null && defaultLayoutXml != "__inherit")
+            if (defaultLayoutXml != null)
             {
                 defaultPageLayoutUrl = XElement.Parse(defaultLayoutXml).Attribute("url").Value;
             }


### PR DESCRIPTION
ctx.Web.GetProvisioningTemplate() throws {"Data at the root level is invalid. Line 1, position 1."}

I added a check in GetAvaliablePageLayouts(Web web) in ObjectPublishing.cs to handle this error:

// if (defaultLayoutXml != null)
if (defaultLayoutXml != null && defaultLayoutXml != "__inherit")
{
defaultPageLayoutUrl = XElement.Parse(defaultLayoutXml).Attribute("url").Value;
}