### PR TITLE
fix for AddFieldToContentType does not set Required=false for field link

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -760,8 +760,15 @@ namespace Microsoft.SharePoint.Client
                 flink = contentType.FieldLinks.GetById(field.Id);
             }
 
-            if (required || hidden)
-            {
+			//update field link required and hidden properties
+			if (!flink.IsObjectPropertyInstantiated("Required") || !flink.IsObjectPropertyInstantiated("Hidden"))
+			{
+				web.Context.Load(flink, f => f.Required, f => f.Hidden);
+				web.Context.ExecuteQueryRetry();
+			}
+
+			if ((required != flink.Required) || (hidden != flink.Hidden))
+			{
                 // Update FieldLink
                 flink.Required = required;
                 flink.Hidden = hidden;


### PR DESCRIPTION
FieldAndContentTypeExtensions.AddFieldToContentType does not apply Required=false when adding field link to content type. It ends up in that in situation when provisioning engine add fields marked as required even when you explicitly set Required attribute to false in pnp:FieldRef node.