### PR TITLE
Include support for EnsureProperties

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ClientObjectExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ClientObjectExtensionsTests.cs
@@ -170,5 +170,72 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
                 Assert.IsTrue(clientContext.Web.IsPropertyAvailable(w => w.ServerRelativeUrl));
             }
         }
+
+        [TestMethod]
+        public void EnsurePropertiesIncludeTest()
+        {
+            using (ClientContext clientContext = TestCommon.CreateClientContext())
+            {
+                //Arrange
+                Exception expectedException = null;
+                Field field = null;
+                string url = null;
+                try
+                {
+                    //Act
+                    clientContext.Web.EnsureProperties(w => w.Fields.Include(f => f.Id, f => f.Title), w => w.Url);
+
+                    //equivalent to
+                    //clientContext.Load(clientContext.Web, w=> w.Url,  w => w.Fields.Include(f => f.Id, f => f.Title));
+                    //clientContext.ExecuteQueryRetry();
+
+                    field = clientContext.Web.Fields[0];
+                    url = clientContext.Web.Url;
+                    var hidden = field.Required;
+                }
+                catch (Exception ex)
+                {
+                    expectedException = ex;
+                }
+
+                //Assert
+                Assert.IsTrue(expectedException is PropertyOrFieldNotInitializedException);
+                Assert.IsTrue(!string.IsNullOrEmpty(field.Title));
+                Assert.IsTrue(!string.IsNullOrEmpty(url));
+            }
+        }
+
+        [TestMethod]
+        public void EnsurePropertyIncludeTest()
+        {
+            using (ClientContext clientContext = TestCommon.CreateClientContext())
+            {
+                //Arrange
+                Exception expectedException = null;
+                Field field = null;
+                try
+                {
+                    //Act
+                    var fields = clientContext.Web.EnsureProperty(w => w.Fields.Include(f => f.Id, f => f.Title)).ToList();
+                    
+                    //equivalent to
+                    //clientContext.Load(clientContext.Web, w => w.Fields.Include(f => f.Id, f => f.Title));
+                    //clientContext.ExecuteQueryRetry();
+                    //var fields = clientContext.Web.Fields;
+
+                    field = fields[0];
+                    
+                    var hidden = field.Required;
+                }
+                catch (Exception ex)
+                {
+                    expectedException = ex;
+                }
+
+                //Assert
+                Assert.IsTrue(expectedException is PropertyOrFieldNotInitializedException);
+                Assert.IsTrue(!string.IsNullOrEmpty(field.Title));
+            }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ClientObjectExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ClientObjectExtensionsTests.cs
@@ -237,5 +237,47 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
                 Assert.IsTrue(!string.IsNullOrEmpty(field.Title));
             }
         }
+
+        [TestMethod]
+        public void EnsureComplexPropertyWithDependencyTest()
+        {
+            using (ClientContext clientContext = TestCommon.CreateClientContext())
+            {
+                //Arrange
+                var fieldTitle1 = clientContext.Web.Fields.GetByInternalNameOrTitle("Title");
+                //at this stage clientContext.Web.IsObjectPropertyInstantiated("Fields") will be true
+                //but actually Fields are not loaded, CollectionNotInitializedException will be thrown when trying to access the collection
+                
+                var fields = clientContext.Web.EnsureProperty(w => w.Fields);
+                
+                //Act
+                var fieldTitle2 = fields.FirstOrDefault(f => f.Title.Equals("Title"));
+
+                //Assert
+                Assert.IsTrue(fieldTitle2 != null);
+                Assert.IsTrue(fieldTitle1 != null);
+            }
+        }
+
+        [TestMethod]
+        public void EnsureComplexPropertiesWithDependencyTest()
+        {
+            using (ClientContext clientContext = TestCommon.CreateClientContext())
+            {
+                //Arrange
+                var fieldTitle1 = clientContext.Web.Fields.GetByInternalNameOrTitle("Title");
+                //at this stage clientContext.Web.IsObjectPropertyInstantiated("Fields") will be true
+                //but actually Fields are not loaded, CollectionNotInitializedException will be thrown when trying to access the collection
+
+                clientContext.Web.EnsureProperties(w => w.Fields);
+
+                //Act
+                var fieldTitle2 = clientContext.Web.Fields.FirstOrDefault(f => f.Title.Equals("Title"));
+
+                //Assert
+                Assert.IsTrue(fieldTitle2 != null);
+                Assert.IsTrue(fieldTitle1 != null);
+            }
+        }
     }
 }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ClientObjectExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ClientObjectExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.SharePoint.Client
 
                     return (TResult)prop.GetValue(clientObject);
                 }
-                throw new Exception("Only 'Include' and 'IncludeWithDefaultProperties' methods supported.");
+                throw new Exception("Only 'Include' and 'IncludeWithDefaultProperties' methods are supported.");
             }
 
             var untypedExpresssion = propertySelector.ToUntypedPropertyExpression();
@@ -107,7 +107,7 @@ namespace Microsoft.SharePoint.Client
                     }
                     else
                     {
-                        throw new Exception("Only 'Include' and 'IncludeWithDefaultProperties' methods supported.");
+                        throw new Exception("Only 'Include' and 'IncludeWithDefaultProperties' methods are supported.");
                     }
                 } else if (!clientObject.IsPropertyAvailable(expression) && !clientObject.IsObjectPropertyInstantiated(expression))
                 {


### PR DESCRIPTION
Now you can write 
```
clientContext.Web.EnsureProperties(w => w.Fields.Include(f => f.Id, f => f.Title), w => w.Url);
```
this will be equal to: 
```
clientContext.Load(clientContext.Web, w=> w.Url,  w => w.Fields.Include(f => f.Id, f => f.Title));
clientContext.ExecuteQueryRetry();
```

Or for single property: 
```
var fields = clientContext.Web.EnsureProperty(w => w.Fields.Include(f => f.Id, f => f.Title)).ToList();
```
equivalent: 
```
clientContext.Load(clientContext.Web, w => w.Fields.Include(f => f.Id, f => f.Title));
clientContext.ExecuteQueryRetry();
var fields = clientContext.Web.Fields;
```