### PR TITLE
Fixed exception thrown when trying to assign same permission twice. 

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/SecurityExtensionsTests.cs
@@ -363,6 +363,25 @@ namespace Microsoft.SharePoint.Client.Tests
                 web.RemovePermissionLevelFromUser(_userLogin, "Approve");
             }
         }
+
+		[TestMethod]
+		public void AddSamePermissionLevelTwiceToGroupTest()
+		{
+			using (ClientContext clientContext = TestCommon.CreateClientContext())
+			{
+				// Test
+				clientContext.Web.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, true);
+				clientContext.Web.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, false);
+
+				//Get Group
+				Group group = clientContext.Web.SiteGroups.GetByName(_testGroupName);
+				clientContext.ExecuteQueryRetry();
+
+				//Assert
+				Assert.IsTrue(CheckPermissionOnPrinciple(clientContext.Web, group, RoleType.Contributor));
+			}
+		}
+
         #endregion
 
         #region Reader access tests


### PR DESCRIPTION
This code:
```
clientContext.Web.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, true);
clientContext.Web.AddPermissionLevelToGroup(_testGroupName, RoleType.Contributor, false);
```
throws an exception `The permission level specified is already added to the collection` in current pnp version. But sometimes in complex scenarios it is possible that code tries to set same permission twice. This was fixed. Also simplified methods `AddPermissionLevelImplementation` and `RemovePermissionLevelImplementation` 