### PR TITLE
Fixed issue with overwriting HomePage (not possible to delete HomePage)

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -22,7 +22,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 var context = web.Context as ClientContext;
 
-                web.EnsureProperties(w => w.ServerRelativeUrl, w => w.RootFolder);
+                web.EnsureProperties(w => w.ServerRelativeUrl, w => w.RootFolder.WelcomePage);
                 
                 foreach (var page in template.Pages)
                 {


### PR DESCRIPTION
If Overwrite is True on a Page that is already HomePage, it cannot be deleted. Hence it isn't overwritten.
Eg.

      <pnp:Pages WelcomePage="{site}/SitePages/Home.aspx">
        <pnp:Page Url="{site}/SitePages/Home.aspx" Overwrite="true" Layout="TwoColumnsHeader">
          <pnp:Security>
            <pnp:BreakRoleInheritance CopyRoleAssignments="false" ClearSubscopes="false" />
          </pnp:Security>
        </pnp:Page>
      </pnp:Pages>