### PR TITLE
Fixed performance issue in ExtractObjects within ListInstance object …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1052,9 +1052,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             list.Fields.Add((new Model.Field { SchemaXml = field.SchemaXml }));
                         }
-
-                        list.Security = siteList.GetSecurity();
                     }
+
+                    list.Security = siteList.GetSecurity();
+
                     var logCTWarning = false;
                     if (baseTemplateList != null)
                     {


### PR DESCRIPTION
…handler.

GetSecurity is called called inside the FieldCollection loop. 
Moved outside the loop.