### PR TITLE
ReIndexList and fix for list SetPropertyBagValue

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -173,6 +173,7 @@ namespace Microsoft.SharePoint.Client
             list.Context.ExecuteQueryRetry();
 
             props[key] = value;
+            list.RootFolder.Update();
             list.Update();
             list.Context.ExecuteQueryRetry();
         }
@@ -1262,5 +1263,20 @@ namespace Microsoft.SharePoint.Client
             }
         }
 
+        /// <summary>
+        /// Queues a list for a full crawl the next incremental crawl
+        /// </summary>
+        /// <param name="list"></param>
+        public static void ReIndexList(this List list)
+        {
+            const string reIndexKey = "vti_searchversion";
+            var searchversion = 0;
+
+            if (list.PropertyBagContainsKey(reIndexKey))
+            {
+                searchversion = (int)list.GetPropertyBagValueInt(reIndexKey, 0);
+            }
+            list.SetPropertyBagValue(reIndexKey, searchversion + 1);
+        }
     }
 }


### PR DESCRIPTION
ReIndexList a method to queue list for reindexing

And a small fix for for setting propertybag value on list (rootfolder).
When using a list object from ClientContex.Web.GetListByUrl the extension methods SetPropertyBagValue methods doesn't work (the values don't stick).