### PR TITLE
Allow zero instances of RoleAssignment under BreakRoleInheritance

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-08.xsd
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-08.xsd
@@ -1206,7 +1206,7 @@
           </xsd:annotation>
 
           <xsd:sequence>
-            <xsd:element name="RoleAssignment" type="pnp:RoleAssignment" maxOccurs="unbounded" />
+            <xsd:element name="RoleAssignment" type="pnp:RoleAssignment" minOccurs="0" maxOccurs="unbounded" />
           </xsd:sequence>
 
           <xsd:attribute name="CopyRoleAssignments" type="xsd:boolean" use="required">


### PR DESCRIPTION
An exported template doesn't necessarily contain RoleAssignments.
If it doesn't, the template cannot be imported as it fails verification against the schema. 