### PR TITLE
MajorVersionLimit is not supported on-premises causes runtime exceptions

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -617,11 +617,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         existingList.EnableVersioning = templateList.EnableVersioning;
                         isDirty = true;
                     }
+#if !CLIENTSDKV15
                     if (existingList.IsObjectPropertyInstantiated("MajorVersionLimit") && existingList.MajorVersionLimit != templateList.MaxVersionLimit)
                     {
                         existingList.MajorVersionLimit = templateList.MaxVersionLimit;
                         isDirty = true;
                     }
+#endif
                     if (existingList.BaseTemplate == (int)ListTemplateType.DocumentLibrary)
                     {
                         // Only supported on Document Libraries
@@ -747,7 +749,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             createdList.EnableVersioning = list.EnableVersioning;
             if (list.EnableVersioning)
             {
+#if !CLIENTSDKV15
                 createdList.MajorVersionLimit = list.MaxVersionLimit;
+#endif
 
                 if (createdList.BaseTemplate == (int)ListTemplateType.DocumentLibrary)
                 {


### PR DESCRIPTION
MajorVersionLimit is not supported on-premises and checking this property will cause a serverside error resulting in a runtime exeption. Adding compiler flags to exclude checking these properties in V15 builds