### PR TITLE
Added support for lookup fields, which isn't a site column

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -463,13 +463,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private static void CreateField(XElement fieldElement, ListInfo listInfo, TokenParser parser)
         {
-            var listIdentifier = fieldElement.Attribute("List") != null ? fieldElement.Attribute("List").Value : null;
-
-            if (listIdentifier != null)
-            {
-                // Temporary remove list attribute from fieldElement
-                fieldElement.Attribute("List").Remove();
-            }
+            fieldElement = PrepareField(fieldElement);
 
             var fieldXml = parser.ParseString(fieldElement.ToString());
             listInfo.SiteList.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint);
@@ -491,15 +485,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 // Is existing field of the same type?
                 if (existingFieldElement.Attribute("Type").Value == templateFieldElement.Attribute("Type").Value)
                 {
-                    var listIdentifier = templateFieldElement.Attribute("List") != null
-                        ? templateFieldElement.Attribute("List").Value
-                        : null;
-
-                    if (listIdentifier != null)
-                    {
-                        // Temporary remove list attribute from list
-                        templateFieldElement.Attribute("List").Remove();
-                    }
+                    templateFieldElement = PrepareField(templateFieldElement);
 
                     foreach (var attribute in templateFieldElement.Attributes())
                     {
@@ -536,6 +522,35 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     WriteWarning(string.Format(CoreResources.Provisioning_ObjectHandlers_ListInstances_Field__0____1___exists_in_list__2____3___but_is_of_different_type__Skipping_field_, fieldName, fieldId, listInfo.TemplateList.Title, listInfo.SiteList.Id), ProvisioningMessageType.Warning);
                 }
             }
+        }
+
+        private static XElement PrepareField(XElement fieldElement)
+        {
+            var listIdentifier = fieldElement.Attribute("List") != null ? fieldElement.Attribute("List").Value : null;
+
+            if (listIdentifier != null)
+            {
+                // Temporary remove list attribute from fieldElement
+                fieldElement.Attribute("List").Remove();
+
+                if (fieldElement.Attribute("RelationshipDeleteBehavior") != null)
+                {
+                    if (fieldElement.Attribute("RelationshipDeleteBehavior").Value.Equals("Restrict") ||
+                        fieldElement.Attribute("RelationshipDeleteBehavior").Value.Equals("Cascade"))
+                    {
+                        // If RelationshipDeleteBehavior is either 'Restrict' or 'Cascade',
+                        // make sure that Indexed is set to TRUE
+                        if (fieldElement.Attribute("Indexed") != null)
+                            fieldElement.Attribute("Indexed").Value = "TRUE";
+                        else
+                            fieldElement.Add(new XAttribute("Indexed", "TRUE"));
+                    }
+
+                    fieldElement.Attribute("RelationshipDeleteBehavior").Remove();
+                }
+            }
+
+            return fieldElement;
         }
 
         private Tuple<List, TokenParser> UpdateList(Web web, List existingList, ListInstance templateList, TokenParser parser, PnPMonitoredScope scope)
@@ -1137,7 +1152,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 else
                 {
                     var schemaXml = ParseFieldSchema(field.SchemaXml, lists);
-                    list.Fields.Add((new Model.Field { SchemaXml = schemaXml }));
+                    var fieldElement = XElement.Parse(field.SchemaXml);
+                    var listId = fieldElement.Attribute("List") != null ? fieldElement.Attribute("List").Value : null;
+
+                    if (listId == null)
+                        list.Fields.Add((new Model.Field { SchemaXml = field.SchemaXml }));
+                    else
+                    {
+                        var listIdValue = Guid.Empty;
+                        if (Guid.TryParse(listId, out listIdValue))
+                        {
+                            var sourceList = lists.AsEnumerable().Where(l => l.Id == listIdValue).FirstOrDefault();
+                            if (sourceList != null)
+                                fieldElement.Attribute("List").SetValue(String.Format("{{listid:{0}}}", sourceList.Title));
+                        }
+
+                        list.Fields.Add(new Model.Field { SchemaXml = fieldElement.ToString() });
+                    }
+
                     if (field.TypeAsString.StartsWith("TaxonomyField"))
                     {
                         // find the corresponding taxonomy field and include it anyway
@@ -1151,6 +1183,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         noteSchemaXml.Attribute("SourceID").Remove();
                         list.Fields.Insert(0, new Model.Field { SchemaXml = ParseFieldSchema(noteSchemaXml.ToString(), lists) });
                     }
+
                 }
             }
             return list;
@@ -1190,4 +1223,3 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         }
     }
 }
-

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
@@ -60,6 +60,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     var fieldId = Guid.Parse(fieldElement.Attribute("ID").Value);
                     var listIdentifier = fieldElement.Attribute("List").Value;
+                    var relationshipDeleteBehavior = fieldElement.Attribute("RelationshipDeleteBehavior") != null ? fieldElement.Attribute("RelationshipDeleteBehavior").Value : "None";
                     var webId = string.Empty;
 
                     var field = rootWeb.Fields.GetById(fieldId);
@@ -84,7 +85,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     if (listGuid != Guid.Empty)
                     {
-                        ProcessField(field, listGuid, webId);
+                        ProcessField(field, listGuid, webId, relationshipDeleteBehavior);
                     }
                 }
             }
@@ -101,6 +102,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     var fieldId = Guid.Parse(fieldElement.Attribute("ID").Value);
                     var listIdentifier = fieldElement.Attribute("List").Value;
+                    var relationshipDeleteBehavior = fieldElement.Attribute("RelationshipDeleteBehavior") != null ? fieldElement.Attribute("RelationshipDeleteBehavior").Value : "None";
                     var webId = string.Empty;
 
                     var listUrl = UrlUtility.Combine(web.ServerRelativeUrl, parser.ParseString(listInstance.Url));
@@ -129,7 +131,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         if (listGuid != Guid.Empty)
                         {
-                            ProcessField(field, listGuid, webId);
+                            ProcessField(field, listGuid, webId, relationshipDeleteBehavior);
                         }
                     }
                 }
@@ -138,7 +140,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
-        private static void ProcessField(Field field, Guid listGuid, string webId)
+        private static void ProcessField(Field field, Guid listGuid, string webId, string relationshipDeleteBehavior)
         {
             var isDirty = false;
 
@@ -149,6 +151,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             isDirty = UpdateFieldAttribute(existingFieldElement, "WebId", webId, isDirty);
 
             isDirty = UpdateFieldAttribute(existingFieldElement, "SourceID", webId, isDirty);
+
+            isDirty = UpdateFieldAttribute(existingFieldElement, "RelationshipDeleteBehavior", relationshipDeleteBehavior, isDirty);
 
             if (isDirty)
             {


### PR DESCRIPTION
When a lookup field is created/update the List attribute is temporarily removed.
In this case the field cannot be created if RelationshipDeleteBehavior is set.
I've fixed this issue and is also making sure Indexed attribute is set to True if RelationshipDeleteBehavior is either Cascade or Restrict.