### PR TITLE
Fixed reintroduced bug where tokens should be excluded when parsing f…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -117,7 +117,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         existingFieldElement.Attributes("Version").Remove();
                     }
-                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString());
+                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString(), "~sitecollection", "~site");
                     existingField.UpdateAndPushChanges(true);
                     web.Context.ExecuteQueryRetry();
                 }
@@ -151,7 +151,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 templateFieldElement.Attribute("List").Remove();
             }
 
-            var fieldXml = parser.ParseString(templateFieldElement.ToString());
+            var fieldXml = parser.ParseString(templateFieldElement.ToString(), "~sitecollection", "~site");
 
             web.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint);
             web.Context.ExecuteQueryRetry();

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -480,7 +480,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 fieldElement.Attribute("List").Remove();
             }
 
-            var fieldXml = parser.ParseString(fieldElement.ToString());
+            var fieldXml = parser.ParseString(fieldElement.ToString(), "~sitecollection", "~site");
             listInfo.SiteList.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint);
             listInfo.SiteList.Context.ExecuteQueryRetry();
         }
@@ -534,7 +534,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         existingFieldElement.Attributes("Version").Remove();
                     }
-                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString());
+                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString(), "~sitecollection", "~site");
                     existingField.UpdateAndPushChanges(true);
                     web.Context.ExecuteQueryRetry();
                 }


### PR DESCRIPTION
…ield.

Parsing of fields was added in following commit.
https://github.com/OfficeDev/PnP-Sites-Core/commit/c9a55b6016f052bcdc9798f460661b6df959d6db

It reintroduced the issue with ~sitecollection token being parsed. 
It means that eg. JSLink won't work as it needs the ~sitecollection token and not the parsed value.