### PR TITLE
provision extensibility providers token parsing

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
@@ -31,6 +31,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         try
                         {
+                            if (!string.IsNullOrEmpty(provider.Configuration))
+                            {
+                                //replace tokens in configuration data
+                                provider.Configuration = parser.ParseString(provider.Configuration);
+                            }
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ExtensibilityProviders_Calling_extensibility_callout__0_, provider.Assembly);
                             _extManager.ExecuteExtensibilityCallOut(context, provider, template);
                         }
@@ -56,7 +61,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             return template;
         }
-
         private ProvisioningTemplate CleanupEntities(ProvisioningTemplate template, ProvisioningTemplate baseTemplate)
         {
 


### PR DESCRIPTION
This is alternative solution to PR #71 (https://github.com/OfficeDev/PnP-Sites-Core/pull/71) tokens in configuration data are replaced before data is passed to provider. If you merge it, please close PR #71