### PR TITLE
Added skipping of tokens ~site and ~sitecollection 

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -117,7 +117,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         existingFieldElement.Attributes("Version").Remove();
                     }
-                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString());
+                    existingField.SchemaXml = parser.ParseString(existingFieldElement.ToString(), "~sitecollection", "~site");
                     existingField.UpdateAndPushChanges(true);
                     web.Context.ExecuteQueryRetry();
                 }
@@ -151,7 +151,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 templateFieldElement.Attribute("List").Remove();
             }
 
-            var fieldXml = parser.ParseString(templateFieldElement.ToString());
+            var fieldXml = parser.ParseString(templateFieldElement.ToString(), "~sitecollection", "~site");
 
             web.Fields.AddFieldAsXml(fieldXml, false, AddFieldOptions.AddFieldInternalNameHint);
             web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
When creating a field containing a JSLink in an XML provisioning template, the ~sitecollection token is incorrecty replaced with the actual url of the site collection, this way the display template is not loaded. I added the skiptokens ~sitecollection and ~site to the call of parsing function within the createfield and updatefield functions.