### PR TITLE
XMLPnPSchemaV201508Formatter - Fix to not to serialize empty ComposedLook

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
@@ -782,7 +782,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             #region Composed Looks
 
             // Translate ComposedLook, if any
-            if (template.ComposedLook != null)
+            if (template.ComposedLook != null && !template.ComposedLook.Equals(Model.ComposedLook.Empty))
             {
                 result.ComposedLook = new V201508.ComposedLook
                 {


### PR DESCRIPTION
Fix for the following issue:

- Create new template (automatically creates empty instance of ComposedLook)
- Do not set ComposedLook
- Save template to XML file - will create ComposedLook node with empty attributes
- Try to read template from resulting XML file

Current fix compares current composed look with empty one, and saves it only if it is not empty.