### PR TITLE
Rethrow provider exceptions

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
@@ -41,7 +41,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                         catch (Exception ex)
                         {
-                            scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ExtensibilityProviders_callout_failed___0_____1_, ex.Message, ex.StackTrace);
+                            scope.LogError(CoreResources.Provisioning_ObjectHandlers_ExtensibilityProviders_callout_failed___0_____1_, ex.Message, ex.StackTrace);
+                            throw;
                         }
                     }
                 }


### PR DESCRIPTION
When using/developing extensibility providers it’s difficult to follow the execution when exceptions inside the providers isn’t exposed. You could use the trace log capabilities but that give you a little bit too much, I just what the error.

Suggestion:
- Log the exception as an error
- Rethrow the exception
