### PR TITLE
Fix for custom actions onprem

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/NavigationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/NavigationExtensions.cs
@@ -660,7 +660,7 @@ namespace Microsoft.SharePoint.Client
                     targetAction.RegistrationId = customAction.RegistrationId;
                 }
 
-                if (customAction.CommandUIExtension != null)
+                if (!string.IsNullOrEmpty(customAction.CommandUIExtension))
                 {
                     targetAction.CommandUIExtension = customAction.CommandUIExtension;
                 }


### PR DESCRIPTION
When applying custom action to onprem (site level) I get a "unknown error" when CommandUIExtension is set to empty string