### PR TITLE
Fixes for provisioning files to list and setting welcome page onprem

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -127,11 +127,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.Load(targetFile, f => f.CheckOutType, f => f.ListItemAllFields.ParentList.ForceCheckout);
                 web.Context.ExecuteQueryRetry();
 
-                if (targetFile.CheckOutType == CheckOutType.None)
+                if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue && !targetFile.ListItemAllFields.ServerObjectIsNull.Value)
                 {
-                    targetFile.CheckOut();
+                    if (targetFile.CheckOutType == CheckOutType.None)
+                    {
+                        targetFile.CheckOut();
+                    }
+                    checkedOut = true;
                 }
-                checkedOut = true;
             }
             catch (ServerException ex)
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -87,6 +87,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     if (page.WelcomePage)
                     {
+                        web.RootFolder.EnsureProperty(p => p.ServerRelativeUrl);
                         var rootFolderRelativeUrl = url.Substring(web.RootFolder.ServerRelativeUrl.Length);
                         web.SetHomePage(rootFolderRelativeUrl);
                     }


### PR DESCRIPTION
When provisioning files "inside" a list (not library) the object handler for files do a checkout (which succeeds) but the checkin fails with "Unknown Error".

When provisioning pages onprem and setting the welcome page the ServerRelativeUrl property fails with an uninstantiated error.