### PR TITLE
When using an OOTB composed look the site logo is not copied across

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -135,7 +135,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 // TH061115: Just because a site is using a OOTB composed look doesnt mean the site logo shouldnt be copied across
                 // check to see if there is a file connector and then download the file if there is.
-                if (string.IsNullOrEmpty(template.ComposedLook.SiteLogo) && creationInfo != null)
+                if (!string.IsNullOrEmpty(template.ComposedLook.SiteLogo) && creationInfo != null)
                 {
                     if (creationInfo.PersistComposedLookFiles && creationInfo.FileConnector != null && !template.ComposedLook.SiteLogo.ToLower().Contains("_layouts"))
                     {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -134,7 +134,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 // TH061115: Just because a site is using a OOTB composed look doesnt mean the site logo shouldnt be copied across
                 // check to see if there is a file connector and then download the file if there is.
-                if (!string.IsNullOrEmpty(template.ComposedLook.SiteLogo))
+                if (CopySiteLogo(template.ComposedLook.SiteLogo))
                 {
                     if (creationInfo != null && creationInfo.FileConnector != null)
                     {
@@ -187,10 +187,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
 
                             template.Files.Add(GetComposedLookFile(template.ComposedLook.FontFile));
-                        }
-                        if (!string.IsNullOrEmpty(template.ComposedLook.SiteLogo))
-                        {
-                            template.Files.Add(GetComposedLookFile(template.ComposedLook.SiteLogo));
                         }
 
                         // If a base template is specified then use that one to "cleanup" the generated template model
@@ -307,6 +303,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             }
             return template;
+        }
+
+        private bool CopySiteLogo(string siteLogo)
+        {
+            if (string.IsNullOrEmpty(siteLogo) || siteLogo.ToLower().Contains("_layouts"))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public override bool WillProvision(Web web, ProvisioningTemplate template)


### PR DESCRIPTION
I have restructured ObjectComposedLook.cs - ExtractObjects so that should the site logo will be downloaded regardless of whether the composed look is custom or not. I realise the OOTB composed looks may not be used as much as custom ones but we need to cater for the times that they are.