### PR TITLE
Do not ignore Sequence property for scriptlink type UserCustomAction

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/NavigationExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/NavigationExtensions.cs
@@ -641,6 +641,7 @@ namespace Microsoft.SharePoint.Client
             targetAction.Name = customAction.Name;
             targetAction.Description = customAction.Description;
             targetAction.Location = customAction.Location;
+            targetAction.Sequence = customAction.Sequence;
 
             if (customAction.Location == JavaScriptExtensions.SCRIPT_LOCATION)
             {
@@ -649,7 +650,6 @@ namespace Microsoft.SharePoint.Client
             }
             else
             {
-                targetAction.Sequence = customAction.Sequence;
                 targetAction.Url = customAction.Url;
                 targetAction.Group = customAction.Group;
                 targetAction.Title = customAction.Title;


### PR DESCRIPTION
Moved "Sequence" property setting out of UserCustomAction type checking.

Sequence is an important property to be used when adding multiple ScriptLink custom actions which might depend on eachother.

Issue reference: #177 

Edit: additional change in pull request #188 by @luismanez. That one seems to be preferred solution since it incorporates change to provisioning engine as well.