### PR TITLE
Composed look null values

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -893,44 +893,46 @@ namespace Microsoft.SharePoint.Client
                     }
 
                     // special case, theme files have been deployed via api and when applying the proper theme the "current" was not set
-                    if (theme.Name.Equals(CurrentLookName, StringComparison.InvariantCultureIgnoreCase))
+                    if (!string.IsNullOrEmpty(theme.Name))
                     {
-                        if (!web.IsUsingOfficeTheme())
+                        if (theme.Name.Equals(CurrentLookName, StringComparison.InvariantCultureIgnoreCase))
                         {
-                            // Assume the the last added custom theme is what the site is using
-                            for (int i = themes.Count; i-- > 0;)
+                            if (!web.IsUsingOfficeTheme())
                             {
-                                var themeItem = themes[i];
-                                if (themeItem["Name"] != null && customComposedLooks.Contains(themeItem["Name"] as string))
+                                // Assume the the last added custom theme is what the site is using
+                                for (int i = themes.Count; i-- > 0;)
                                 {
-                                    if (themeItem["ThemeUrl"] != null && themeItem["ThemeUrl"].ToString().Length > 0)
+                                    var themeItem = themes[i];
+                                    if (themeItem["Name"] != null && customComposedLooks.Contains(themeItem["Name"] as string))
                                     {
-                                        theme.Theme = (themeItem["ThemeUrl"] as FieldUrlValue).Url;
-                                    }
-                                    if (themeItem["MasterPageUrl"] != null && themeItem["MasterPageUrl"].ToString().Length > 0)
-                                    {
-                                        theme.MasterPage = (themeItem["MasterPageUrl"] as FieldUrlValue).Url;
-                                    }
-                                    if (themeItem["FontSchemeUrl"] != null && themeItem["FontSchemeUrl"].ToString().Length > 0)
-                                    {
-                                        theme.Font = (themeItem["FontSchemeUrl"] as FieldUrlValue).Url;
-                                    }
-                                    if (themeItem["ImageUrl"] != null && themeItem["ImageUrl"].ToString().Length > 0)
-                                    {
-                                        theme.BackgroundImage = (themeItem["ImageUrl"] as FieldUrlValue).Url;
-                                    }
-                                    if (themeItem["Name"] != null && themeItem["Name"].ToString().Length > 0)
-                                    {
-                                        theme.Name = themeItem["Name"] as String;
-                                    }
+                                        if (themeItem["ThemeUrl"] != null && themeItem["ThemeUrl"].ToString().Length > 0)
+                                        {
+                                            theme.Theme = (themeItem["ThemeUrl"] as FieldUrlValue).Url;
+                                        }
+                                        if (themeItem["MasterPageUrl"] != null && themeItem["MasterPageUrl"].ToString().Length > 0)
+                                        {
+                                            theme.MasterPage = (themeItem["MasterPageUrl"] as FieldUrlValue).Url;
+                                        }
+                                        if (themeItem["FontSchemeUrl"] != null && themeItem["FontSchemeUrl"].ToString().Length > 0)
+                                        {
+                                            theme.Font = (themeItem["FontSchemeUrl"] as FieldUrlValue).Url;
+                                        }
+                                        if (themeItem["ImageUrl"] != null && themeItem["ImageUrl"].ToString().Length > 0)
+                                        {
+                                            theme.BackgroundImage = (themeItem["ImageUrl"] as FieldUrlValue).Url;
+                                        }
+                                        if (themeItem["Name"] != null && themeItem["Name"].ToString().Length > 0)
+                                        {
+                                            theme.Name = themeItem["Name"] as String;
+                                        }
 
-                                    theme.IsCustomComposedLook = true;
-                                    break;
+                                        theme.IsCustomComposedLook = true;
+                                        break;
+                                    }
                                 }
                             }
                         }
                     }
-
                 }
             }
 
@@ -944,10 +946,13 @@ namespace Microsoft.SharePoint.Client
             // If name still is "Current" and there isn't a PreviewThemedCssFolderUrl 
             // property in the property bag then we can't correctly determine the set 
             // composed look...so return null
-            if (theme.Name.Equals(CurrentLookName, StringComparison.InvariantCultureIgnoreCase)
-                && String.IsNullOrEmpty(designPreviewThemedCssFolderUrl))
+            if (!string.IsNullOrEmpty(theme.Name))
             {
-                return null;
+                if (theme.Name.Equals(CurrentLookName, StringComparison.InvariantCultureIgnoreCase)
+                && String.IsNullOrEmpty(designPreviewThemedCssFolderUrl))
+                {
+                    return null;
+                }
             }
 
             // Clean up the fully qualified urls

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -874,9 +874,7 @@ namespace Microsoft.SharePoint.Client
                         }
 
                         // Note: do not take in account the ImageUrl field as this will point to a copied image in case of a sub site
-                        if ((masterPageUrl == null || theme.MasterPage == null || theme.MasterPage.Equals(masterPageUrl, StringComparison.InvariantCultureIgnoreCase)) &&
-                            (fontUrl == null || theme.Font == null || theme.Font.Equals(fontUrl, StringComparison.InvariantCultureIgnoreCase)) &&
-                            (themeUrl == null || theme.Theme == null || theme.Theme.Equals(themeUrl, StringComparison.InvariantCultureIgnoreCase)))
+                        if (IsMatchingTheme(theme, masterPageUrl, themeUrl, fontUrl))
                         {
                             theme.Name = name;
                             theme.IsCustomComposedLook = !defaultComposedLooks.Contains(theme.Name);
@@ -974,6 +972,83 @@ namespace Microsoft.SharePoint.Client
             }
 
             return theme;
+        }
+
+        /// <summary>
+        /// Compares master page URL, theme URL and font URL values to current theme entity to check if they are the same.
+        /// Handles also possible null values. Point is to figure out which theme is the one that is currently
+        /// being selected as "Current"
+        /// </summary>
+        /// <param name="theme">Current theme entity to compare values to</param>
+        /// <param name="masterPageUrl">Master page URL</param>
+        /// <param name="themeUrl">Theme URL</param>
+        /// <param name="fontUrl">Font URL</param>
+        /// <returns></returns>
+        private static bool IsMatchingTheme(ThemeEntity theme, string masterPageUrl, string themeUrl, string fontUrl)
+        {
+            var themeUrlHasValue = false;
+            var fontUrlHasValue = false;
+            var masterPageUrlHasValue = false;
+
+            // Is theme URL meaningful for compare?
+            if (!string.IsNullOrEmpty(theme.Theme))
+            {
+                themeUrlHasValue = true;
+            }
+
+            // Is font URL meaningful for compare?
+            if (!string.IsNullOrEmpty(theme.Font))
+            {
+                fontUrlHasValue = true;
+            }
+
+            // Is master page URL meaningful for compare?
+            if (!string.IsNullOrEmpty(theme.MasterPage))
+            {
+                masterPageUrlHasValue = true;
+            }
+
+            // Should we compare all of the values?
+            if (themeUrlHasValue && fontUrlHasValue && masterPageUrlHasValue)
+            {
+                if (theme.MasterPage.Equals(masterPageUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                    theme.Theme.Equals(themeUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                    theme.Font.Equals(fontUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // Should we compare only master page and theme URL?
+            if (themeUrlHasValue && !fontUrlHasValue && masterPageUrlHasValue)
+            {
+                if (theme.MasterPage.Equals(masterPageUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                    theme.Theme.Equals(themeUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // Should we compare only master page and font value?
+            if (!themeUrlHasValue && fontUrlHasValue && masterPageUrlHasValue)
+            {
+                if (theme.MasterPage.Equals(masterPageUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                    theme.Font.Equals(fontUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // Should we only compare master page
+            if (!themeUrlHasValue && !fontUrlHasValue && masterPageUrlHasValue)
+            {
+                if (theme.MasterPage.Equals(masterPageUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsUsingOfficeTheme(this Web web)


### PR DESCRIPTION
This request revolves around the fact that when a new PWA project is created the "Current" composed look has null values for all of the fields, this request basically introduces some extra checks to ensure values are not null before being used as a comparison.