### PR TITLE
Changes to GetCurrentComposedLook method

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -715,7 +715,7 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
             
             // if it does not exist then fallback to CurrentLookName 
-            if (currentTheme["Name"] != null && string.IsNullOrEmpty(currentTheme["Name"].ToString())) 
+            if (currentTheme["Name"] != null && !string.IsNullOrEmpty(currentTheme["Name"].ToString())) 
                 themeName = currentTheme["Name"].ToString();
 
             return GetComposedLook(web, themeName);

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -704,8 +704,21 @@ namespace Microsoft.SharePoint.Client
         /// <param name="web">Web to check</param>
         /// <returns>Entity with attributes of current composed look, or null if none</returns>
         public static ThemeEntity GetCurrentComposedLook(this Web web)
-        {
-            return GetComposedLook(web, CurrentLookName);
+        {   
+            var themeName = CurrentLookName;
+            // get the catalog
+            var designCatalog = web.GetCatalog((int)ListTemplateType.DesignCatalog);
+            // get the first item, as it is always the "Current", and we dont get naming issues, as in finnish site it is "Nykyinen"
+            var currentTheme = designCatalog.GetItemById(1);
+             // return the name of the Theme
+            web.Context.Load(currentTheme, theme => theme["Name"]);
+            web.Context.ExecuteQueryRetry();
+            
+            // if it does not exist then fallback to CurrentLookName 
+            if (currentTheme["Name"] != null && string.IsNullOrEmpty(currentTheme["Name"].ToString())) 
+                themeName = currentTheme["Name"].ToString();
+
+            return GetComposedLook(web, themeName);
         }
 
         /// <summary>

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -715,7 +715,7 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
             
             // if it does not exist then fallback to CurrentLookName 
-            if (currentTheme["Name"] != null && !string.IsNullOrEmpty(currentTheme["Name"].ToString())) 
+            if (currentTheme.FieldValues.ContainsKey("Name") && !string.IsNullOrEmpty(currentTheme["Name"].ToString())) 
                 themeName = currentTheme["Name"].ToString();
 
             return GetComposedLook(web, themeName);


### PR DESCRIPTION
Changes to GetCurrentComposedLook method, to work also in sites are not in english. In English sites the current name of the theme is "Current" but in finnish sites for example it is "Nykyinen", so the method will fail. But if we use the id of the item, which is always 1, then we will get always the right theme.