### PR TITLE
Setting the composed look master page whilst there is a space in the the web url

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -9,6 +9,7 @@ using OfficeDevPnP.Core.Entities;
 using LanguageTemplateHash = System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>;
 using Utility = OfficeDevPnP.Core.Utilities.Utility;
 using OfficeDevPnP.Core.Diagnostics;
+using System.Web;
 
 namespace Microsoft.SharePoint.Client
 {
@@ -212,7 +213,7 @@ namespace Microsoft.SharePoint.Client
                     var lookMasterUrl = item["MasterPageUrl"] as FieldUrlValue;
                     if (lookMasterUrl != null)
                     {
-                        masterUrl = new Uri(lookMasterUrl.Url).AbsolutePath;
+                        masterUrl = HttpUtility.UrlDecode(new Uri(lookMasterUrl.Url).AbsolutePath);
                     }
                 }
                 else


### PR DESCRIPTION
When the master page is set using an encoded url it throws an error if there are any spaces in the sub site, decoding it and stripping out the "%20" resolves the issue.