### PR TITLE
Fix for #212: Do not delete folder content type from provisioned document libraries

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -870,8 +870,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             // Effectively remove existing content types, if any
             foreach (var ct in contentTypesToRemove)
             {
-                ct.DeleteObject();
-                web.Context.ExecuteQueryRetry();
+                var shouldDelete = true;
+                shouldDelete &= (createdList.BaseTemplate != (int)ListTemplateType.DocumentLibrary || !ct.StringId.StartsWith(BuiltInContentTypeId.Folder + "00")); 
+
+                if (shouldDelete)
+                {
+                    ct.DeleteObject();
+                    web.Context.ExecuteQueryRetry();
+                }
             }
 
             if (list.Security != null)


### PR DESCRIPTION
Fix for issue #212: The Folder content type should not be deleted from a created document library even if the Remove Existing Content Types -flag is set in the template.