### PR TITLE
Make updated list titles available as tokens in the Provisioning Engine

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -574,7 +574,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 l => l.EnableFolderCreation,
                 l => l.EnableMinorVersions,
                 l => l.DraftVersionVisibility,
-                l => l.Views
+                l => l.Views,
+                l => l.RootFolder
 #if !CLIENTSDKV15
 , l => l.MajorWithMinorVersionsLimit
 #endif
@@ -587,6 +588,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (parser.ParseString(templateList.Title) != existingList.Title)
                 {
                     existingList.Title = parser.ParseString(templateList.Title);
+                    parser.AddToken(new ListIdToken(web, existingList.Title, existingList.Id));
+                    parser.AddToken(new ListUrlToken(web, existingList.Title, existingList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)));
                     isDirty = true;
                 }
                 if (!string.IsNullOrEmpty(templateList.DocumentTemplate))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -587,9 +587,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var isDirty = false;
                 if (parser.ParseString(templateList.Title) != existingList.Title)
                 {
+                    var oldTitle = existingList.Title;
                     existingList.Title = parser.ParseString(templateList.Title);
-                    parser.AddToken(new ListIdToken(web, existingList.Title, existingList.Id));
-                    parser.AddToken(new ListUrlToken(web, existingList.Title, existingList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)));
+                    if (! oldTitle.Equals(existingList.Title, StringComparison.OrdinalIgnoreCase))
+                    { 
+                        parser.AddToken(new ListIdToken(web, existingList.Title, existingList.Id));
+                        parser.AddToken(new ListUrlToken(web, existingList.Title, existingList.RootFolder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length + 1)));
+                    }
                     isDirty = true;
                 }
                 if (!string.IsNullOrEmpty(templateList.DocumentTemplate))


### PR DESCRIPTION
Currently when the provisioning engine changes the list title, the new title is not available as a token in the TokenParser. This makes the following scenario quite hard:

1. Provisioning template is used to rename an out-of-the box SharePoint list (for example Documents -library)
2. If the listId is needed in the template (for example in the webpart definitions), the template must use the {listid:Documents} token since that was the original title of the library and the updated title is not available as a token.
3. Later on some changes are made to the template and the template is reapplied to the existing site.
4. But now the {listid:Documents} token no longer works, since the Document library title has been changed when the template was applied the first time.

So we cannot create a template which will work both when applied the template 1st time and when updating an already provisioned site.

This PR contains changes that will make the updated list title available in the TokenParser whenever a list title is changed by the provisioning engine. After this change the tokens "{listid:updated title}" and "{listurl:updated title}" will work both when applying the template for the first time and for the subsequent calls also.