### PR TITLE
Update XMLPnPSchemaV201508Formatter.cs

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
@@ -815,7 +815,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                              Description = wd.Description,
                              DisplayName = wd.DisplayName,
                              DraftVersion = wd.DraftVersion,
-                             FormField = wd.FormField.ToXmlElement(),
+                             FormField = (wd.FormField != null) ? wd.FormField.ToXmlElement() : null,
                              Id = wd.Id.ToString(),
                              InitiationUrl = wd.InitiationUrl,
                              Properties = (wd.Properties != null && wd.Properties.Count > 0) ?


### PR DESCRIPTION
Setting FormField to wd.Formfield.ToXmlElement() is generating error: {"Value cannot be null.\r\nParameter name: xml"}. Aded check for null on wd.FormField.