### PR TITLE
Making ExternalSharingExtensions class public

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ExternalSharingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ExternalSharingExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SharePoint.Client
         View
     }
 
-    static partial class ExternalSharingExtensions
+    public static partial class ExternalSharingExtensions
     {
         /// <summary>
         /// Can be used to get needed people picker search result value for given email account. 


### PR DESCRIPTION
The *ExternalSharingExtensions* class was not set to public, making it unable to use in other applications.