### PR TITLE
fix for provisioning engine pnp:Page parsing

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Page.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Page.cs
@@ -53,10 +53,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
                 this.WebParts.AddRange(webParts);
             }
 
-            if (security != null)
-            {
-                this.Security = security;
-            }
+            this.Security = security;
         }
 
 


### PR DESCRIPTION
Page element in provisioning template is parsed in a way that Security property is not null, even if Security element for the page is not specified. That brings trouble with permissions removal for the page, when Security element is omitted.