### PR TITLE
Not honoring forcecheckin will cause sideffects

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectFilesTests.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.WebParts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using File = OfficeDevPnP.Core.Framework.Provisioning.Model.File;
+using WebPart = OfficeDevPnP.Core.Framework.Provisioning.Model.WebPart;
 
 namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 {
@@ -17,6 +19,37 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         private string resourceFolder;
         private const string fileName = "ProvisioningTemplate-2015-03-Sample-01.xml";
         private string folder;
+        private string webpartcontents = @"<webParts><webPart xmlns=""http://schemas.microsoft.com/WebPart/v3""><metaData><type name=""Microsoft.SharePoint.WebPartPages.ScriptEditorWebPart, Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"" /><importErrorMessage>Cannot import this Web Part.</importErrorMessage>
+    </metaData>
+    <data>
+      <properties>
+        <property name=""ExportMode"" type=""exportmode"">All</property>
+        <property name=""HelpUrl"" type=""string"" />
+        <property name=""Hidden"" type=""bool"">False</property>
+        <property name=""Description"" type=""string"">Allows authors to insert HTML snippets or scripts.</property>
+        <property name=""Content"" type=""string"">&lt;script type=""text/javascript""&gt;
+alert(""Hello!"");
+&lt;/script&gt;</property>
+        <property name=""CatalogIconImageUrl"" type=""string"" />
+        <property name=""Title"" type=""string"">Script Editor</property>
+        <property name=""AllowHide"" type=""bool"">True</property>
+        <property name=""AllowMinimize"" type=""bool"">True</property>
+        <property name=""AllowZoneChange"" type=""bool"">True</property>
+        <property name=""TitleUrl"" type=""string"" />
+        <property name=""ChromeType"" type=""chrometype"">None</property>
+        <property name=""AllowConnect"" type=""bool"">True</property>
+        <property name=""Width"" type=""unit"" />
+        <property name=""Height"" type=""unit"" />
+        <property name=""HelpMode"" type=""helpmode"">Navigate</property>
+        <property name=""AllowEdit"" type=""bool"">True</property>
+        <property name=""TitleIconImageUrl"" type=""string"" />
+        <property name=""Direction"" type=""direction"">NotSet</property>
+        <property name=""AllowClose"" type=""bool"">True</property>
+        <property name=""ChromeState"" type=""chromestate"">Normal</property>
+      </properties>
+    </data>
+  </webPart>
+</webParts>";
 
         [TestInitialize]
         public void Initialize()
@@ -79,6 +112,69 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             }
         }
 
+        [TestMethod]
+        public void CanAddWebPartsToForms()
+        {
+            var template = new ProvisioningTemplate();
+
+            FileSystemConnector connector = new FileSystemConnector(resourceFolder + @"\..", "");
+
+            template.Connector = connector;
+            var webPart = new WebPart
+            {
+                Column = 1,
+                Row = 1,
+                Contents = webpartcontents,
+                Title = "Script Editor",
+                Order = 0,
+                Zone = "Main"
+            };
+
+            var myfile = new Core.Framework.Provisioning.Model.File()
+            {
+                Overwrite = false,
+                Src = "EditForm.aspx",
+                Folder = "SitePages/Forms"
+            };
+            myfile.WebParts.Add(webPart);
+            template.Files.Add(myfile);
+
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                var parser = new TokenParser(ctx.Web, template);
+                new ObjectFiles().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
+
+                ctx.Web.EnsureProperties(w => w.ServerRelativeUrl);
+
+                var file = ctx.Web.GetFileByServerRelativeUrl(
+                    UrlUtility.Combine(ctx.Web.ServerRelativeUrl,
+                        UrlUtility.Combine("SitePages/Forms", "EditForm.aspx")));
+                ctx.Load(file, f => f.Exists);
+                ctx.ExecuteQueryRetry();
+
+                // first of all do we even find the form ?
+                Assert.IsTrue(file.Exists);
+                var webParts = file.GetLimitedWebPartManager(PersonalizationScope.Shared).WebParts;
+                ctx.Load(webParts, wp => wp.IncludeWithDefaultProperties(w=>w.Id, w=>w.WebPart, w=>w.WebPart.Title));
+                ctx.ExecuteQueryRetry();
+
+                var webPartsArray = webParts.ToArray();
+                var webPartExists = false;
+                foreach (var webPartDefinition in webPartsArray)
+                {
+                    if (webPartDefinition.WebPart.Title == "Script Editor")
+                    {
+                        webPartExists = true;
+                        // cleanup after ourselves if we can find the webpart... 
+                        webPartDefinition.DeleteWebPart();
+                    }
+                   
+                }
+                ctx.ExecuteQueryRetry();
+                Assert.IsTrue(webPartExists);
+            }
+        }
+
 
         [TestMethod]
         public void CanProvisionObjectsRequiredField()
@@ -119,14 +215,14 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 foreach (var list in template.Lists)
                 {
                     ctx.Web.GetListByUrl(list.Url).DeleteObject();
-                    
+
                 }
-            
+
                 foreach (var ct in template.ContentTypes)
                 {
                     ctx.Web.GetContentTypeById(ct.Id).DeleteObject();
                 }
-           
+
                 var idsToDelete = new List<Guid>();
                 foreach (var field in ctx.Web.Fields)
                 {

--- a/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -299,6 +299,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Resources\HelloWorldApp.app" />
+    <Content Include="Resources\EditForm.aspx">
+      <SubType>ASPXCodeBehind</SubType>
+    </Content>
     <Content Include="Resources\garagebg.jpg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Core/OfficeDevPnP.Core.Tests/Resources/EditForm.aspx
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/EditForm.aspx
@@ -1,0 +1,1 @@
+﻿<!-- This is a dummy file used to provision form webparts -->

--- a/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2015-03-Sample-01.xml
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2015-03-Sample-01.xml
@@ -30,7 +30,7 @@
     <pnp:File Src="/Resources/Files/SAMPLE.js" Folder="SAMPLE"/>
   </pnp:Files>
   <pnp:SiteFields>
-    <Field ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Type="Text" Name="ProjectID" DisplayName="Project ID" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" />
+    <Field ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Type="Text" Name="ProjectID" DisplayName="Project ID" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" Required="TRUE" />
     <Field ID="{B01B3DBC-4630-4ED1-B5BA-321BC7841E3D}" Type="Text" Name="ProjectName" DisplayName="Project Name" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" />
     <Field ID="{A5DE9600-B7A6-42DD-A05E-10D4F1500208}" Type="Text" Name="ProjectManager" DisplayName="Project Manager" Group="My Columns"  MaxLength="255" AllowDeletion="TRUE" />
     <Field ID="{F1A1715E-6C52-40DE-8403-E9AAFD0470D0}" Type="Text" Name="DocumentDescription" DisplayName="Document Description" Group="My Columns " MaxLength="255" AllowDeletion="TRUE" />
@@ -43,7 +43,7 @@
                  Inherits="true"
                  Version="0">
       <FieldRefs>
-        <FieldRef ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Name="ProjectID" DisplayName="Project ID" />
+        <FieldRef ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Name="ProjectID" DisplayName="Project ID" Required="TRUE"/>
         <FieldRef ID="{B01B3DBC-4630-4ED1-B5BA-321BC7841E3D}" Name="ProjectName" DisplayName="Project Name" />
         <FieldRef ID="{A5DE9600-B7A6-42DD-A05E-10D4F1500208}" Name="ProjectManager" DisplayName="Project Manager" />
         <FieldRef ID="{F1A1715E-6C52-40DE-8403-E9AAFD0470D0}" Name="DocumentDescription" DisplayName="Document Description" />

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -126,8 +126,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 web.Context.Load(targetFile, f => f.CheckOutType, f => f.ListItemAllFields.ParentList.ForceCheckout);
                 web.Context.ExecuteQueryRetry();
-
-                if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue && !targetFile.ListItemAllFields.ServerObjectIsNull.Value)
+                if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue 
+                    && !targetFile.ListItemAllFields.ServerObjectIsNull.Value 
+                    && targetFile.ListItemAllFields.ParentList.ForceCheckout)
                 {
                     if (targetFile.CheckOutType == CheckOutType.None)
                     {


### PR DESCRIPTION
I've added two test cases and a bug fix for the following issue:

CheckOutIfNeeded is not honoring the default behavior dictated by forcecheckin on lists. This has the effect that 

1) we will not be able to add webparts to forms 
2) we will not be able to upload files (to lists with forcecheckin=false) unless all required parameters are set

Usecase for 1) is pretty obvious (e.g. a ContentEditor with some additional info, or a listview webpart etc)

Usecase for 2) is cases when you want to pre-populate a document library with files, where even required attributes are empty. If the user wants to modify these files in any way they have to fill in the required attriburtes. If, however, we have to pre-populate all these fields with some dummy values (or "not set" values), the user can freely modify the file without ever being prompted to evaluate the data in these fields. 

I've included a test case for each scenario, the bugfix for both is the same. Please review the test cases for details  