### PR TITLE
Update XMLPnPSchemaV201508Formatter.cs - Issue #236

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201508Formatter.cs
@@ -1160,7 +1160,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                 {
                     AuditLogTrimmingRetention = source.AuditSettings.AuditLogTrimmingRetentionSpecified ? source.AuditSettings.AuditLogTrimmingRetention : 0,
                     TrimAuditLog = source.AuditSettings.TrimAuditLogSpecified ? source.AuditSettings.TrimAuditLog : false,
-                    AuditFlags = source.AuditSettings.Audit.Aggregate(Microsoft.SharePoint.Client.AuditMaskType.None, (acc, next) => acc &= (Microsoft.SharePoint.Client.AuditMaskType)Enum.Parse(typeof(Microsoft.SharePoint.Client.AuditMaskType), next.AuditFlag.ToString())),
+                    AuditFlags = source.AuditSettings.Audit.Aggregate(Microsoft.SharePoint.Client.AuditMaskType.None, (acc, next) => acc |= (Microsoft.SharePoint.Client.AuditMaskType)Enum.Parse(typeof(Microsoft.SharePoint.Client.AuditMaskType), next.AuditFlag.ToString())),
                 };
             }
 


### PR DESCRIPTION
Replace &= with |= to allow bitwise or to aggregate discrete audit mask values into the models AuditSettings.AuditFlags property.