### PR TITLE
Browser-based login

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -113,7 +113,7 @@ namespace OfficeDevPnP.Core
         }
 
         /// <summary>
-        /// Returns a SharePoint on-premises / SharePoint Online ClientContext object. Requires claims based authentication with FedAuth/rtFa cookies.
+        /// Returns a SharePoint on-premises / SharePoint Online ClientContext object. Requires claims based authentication with FedAuth cookie.
         /// </summary>
         /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
         /// <returns>ClientContext to be used by CSOM code</returns>
@@ -144,7 +144,7 @@ namespace OfficeDevPnP.Core
                     if (siteUri.Host.Equals(args.Url.Host))
                     {
                         var cookieString = CookieReader.GetCookie(siteUrl).Replace("; ", ",").Replace(";", ",");
-                        if (Regex.IsMatch(cookieString, "FedAuth", RegexOptions.IgnoreCase) && Regex.IsMatch(cookieString, "rtFa", RegexOptions.IgnoreCase))
+                        if (Regex.IsMatch(cookieString, "FedAuth", RegexOptions.IgnoreCase))
                         {
                             var _cookies = cookieString.Split(',').Where(c => c.StartsWith("FedAuth", StringComparison.InvariantCultureIgnoreCase) || c.StartsWith("rtFa", StringComparison.InvariantCultureIgnoreCase));
                             cookies.SetCookies(siteUri, string.Join(",", _cookies));

--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Net;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.IdentityModel.TokenProviders.ADFS;
@@ -108,6 +110,67 @@ namespace OfficeDevPnP.Core
             ClientContext clientContext = new ClientContext(siteUrl);
             clientContext.Credentials = new NetworkCredential(user, password, domain);
             return clientContext;
+        }
+
+        /// <summary>
+        /// Returns a SharePoint on-premises / SharePoint Online ClientContext object. Requires claims based authentication with FedAuth/rtFa cookies.
+        /// </summary>
+        /// <param name="siteUrl">Site for which the ClientContext object will be instantiated</param>
+        /// <returns>ClientContext to be used by CSOM code</returns>
+        public ClientContext GetWebLoginClientContext(string siteUrl)
+        {
+            var cookies = new CookieContainer();
+            var siteUri = new Uri(siteUrl);
+
+            var thread = new Thread(() =>
+            {
+                var form = new System.Windows.Forms.Form();
+                var browser = new System.Windows.Forms.WebBrowser();
+
+                browser.ScriptErrorsSuppressed = true;
+                browser.Dock = DockStyle.Fill;
+
+                form.SuspendLayout();
+                form.Width = 900;
+                form.Height = 500;
+                form.Text = string.Format("Log in to {0}", siteUrl);
+                form.Controls.Add(browser);
+                form.ResumeLayout(false);
+
+                browser.Navigate(siteUri);
+
+                browser.Navigated += (sender, args) =>
+                {
+                    if (siteUri.Host.Equals(args.Url.Host))
+                    {
+                        var cookieString = CookieReader.GetCookie(siteUrl).Replace("; ", ",").Replace(";", ",");
+                        if (Regex.IsMatch(cookieString, "FedAuth", RegexOptions.IgnoreCase) && Regex.IsMatch(cookieString, "rtFa", RegexOptions.IgnoreCase))
+                        {
+                            var _cookies = cookieString.Split(',').Where(c => c.StartsWith("FedAuth", StringComparison.InvariantCultureIgnoreCase) || c.StartsWith("rtFa", StringComparison.InvariantCultureIgnoreCase));
+                            cookies.SetCookies(siteUri, string.Join(",", _cookies));
+                            form.Close();
+                        }
+                    }
+                };
+
+                form.Focus();
+                form.ShowDialog();
+                browser.Dispose();
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (cookies.Count > 0)
+            {
+                var ctx = new ClientContext(siteUrl);
+                ctx.ExecutingWebRequest += (sender, e) => e.WebRequestExecutor.WebRequest.CookieContainer = cookies;
+                return ctx;
+
+            }
+
+            return null;
         }
 
 #if !CLIENTSDKV15

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -234,6 +234,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Services" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -486,6 +487,7 @@
     <Compile Include="Framework\TimerJobs\TimerJob.cs" />
     <Compile Include="Framework\TimerJobs\TimerJobRun.cs" />
     <Compile Include="Framework\TimerJobs\TimerJobRunEventArgs.cs" />
+    <Compile Include="Utilities\CookieReader.cs" />
     <Compile Include="Utilities\Deprecated\Utility.deprecated.cs" />
     <Compile Include="Utilities\FileTokenCache.cs" />
     <Compile Include="Framework\TimerJobs\Utilities\SiteEnumeration.cs" />

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -188,12 +188,12 @@
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.18.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.18.206251556\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.19.208020213\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.18.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.18.206251556\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.19.208020213\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca, processorArchitecture=MSIL" />

--- a/Core/OfficeDevPnP.Core/Utilities/CookieReader.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/CookieReader.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+
+
+
+namespace OfficeDevPnP.Core.Utilities
+{
+    //Taken from "Remote Authentication in SharePoint Online Using the Client Object Model"
+    //https://code.msdn.microsoft.com/Remote-Authentication-in-b7b6f43c
+
+    /// <summary>
+    /// WinInet.dll wrapper
+    /// </summary>
+    internal static class CookieReader
+    {
+        /// <summary>
+        /// Enables the retrieval of cookies that are marked as "HTTPOnly". 
+        /// Do not use this flag if you expose a scriptable interface, 
+        /// because this has security implications. It is imperative that 
+        /// you use this flag only if you can guarantee that you will never 
+        /// expose the cookie to third-party code by way of an 
+        /// extensibility mechanism you provide. 
+        /// Version:  Requires Internet Explorer 8.0 or later.
+        /// </summary>
+        private const int INTERNET_COOKIE_HTTPONLY = 0x00002000;
+
+        /// <summary>
+        /// Returns cookie contents as a string
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public static string GetCookie(string url)
+        {
+
+            int size = 512;
+            StringBuilder sb = new StringBuilder(size);
+            if (!NativeMethods.InternetGetCookieEx(url, null, sb, ref size, INTERNET_COOKIE_HTTPONLY, IntPtr.Zero))
+            {
+                if (size < 0)
+                {
+                    return null;
+                }
+                sb = new StringBuilder(size);
+                if (!NativeMethods.InternetGetCookieEx(url, null, sb, ref size, INTERNET_COOKIE_HTTPONLY, IntPtr.Zero))
+                {
+                    return null;
+                }
+            }
+            return sb.ToString();
+        }
+
+        private static class NativeMethods
+        {
+
+            [DllImport("wininet.dll", EntryPoint = "InternetGetCookieEx", CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern bool InternetGetCookieEx(
+                string url,
+                string cookieName,
+                StringBuilder cookieData,
+                ref int size,
+                int flags,
+                IntPtr pReserved);
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/packages.config
+++ b/Core/OfficeDevPnP.Core/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.18.206251556" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.19.208020213" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.2" targetFramework="net45" />


### PR DESCRIPTION
**Browser-based login and context creating, trough the Browser control.**
Had a project where we had multi-factor authentication and federated adfs authentication enabled at the tenant also app passwords didn't work and we really needed the provisioning engine.

So i put together this browser-based login that uses the WinForms WebBrower control and catches the auth cookies. Manly based on [Remote authentication in SharePoint Online](https://code.msdn.microsoft.com/Remote-Authentication-in-b7b6f43c).

It worked for us and maybe somebody else will find it useful.