### PR TITLE
ObjectHandlerBase Tokenize

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -55,13 +55,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     return url.Substring(url.IndexOf("/_catalogs/masterpage", StringComparison.InvariantCultureIgnoreCase)).Replace("/_catalogs/masterpage", "{masterpagecatalog}");
                 }
-                Uri uri;
+                if (url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase) > -1)
+                {
+                    return url.Replace(webUrl, "{site}");
+                }
                 if (url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase) > -1)
                 {
                     return url.Substring(url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase)).Replace(webUrl, "{site}");
                 }
                 else
                 {
+                    Uri uri;
                     if (Uri.TryCreate(webUrl, UriKind.Absolute, out uri))
                     {
                         if (uri.PathAndQuery != "/")

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -56,14 +56,21 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     return url.Substring(url.IndexOf("/_catalogs/masterpage", StringComparison.InvariantCultureIgnoreCase)).Replace("/_catalogs/masterpage", "{masterpagecatalog}");
                 }
                 Uri uri;
-                if(Uri.TryCreate(webUrl, UriKind.Absolute, out uri))
+                if (url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase) > -1)
                 {
-                    if (uri.PathAndQuery != "/")
+                    return url.Substring(url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase)).Replace(webUrl, "{site}");
+                }
+                else
+                {
+                    if (Uri.TryCreate(webUrl, UriKind.Absolute, out uri))
                     {
-                        var webUrlPathAndQuery = HttpUtility.UrlDecode(uri.PathAndQuery);
-                        if (url.IndexOf(webUrlPathAndQuery, StringComparison.InvariantCultureIgnoreCase) > -1)
+                        if (uri.PathAndQuery != "/")
                         {
-                            return url.Replace(webUrlPathAndQuery, "{site}");
+                            var webUrlPathAndQuery = HttpUtility.UrlDecode(uri.PathAndQuery);
+                            if (url.IndexOf(webUrlPathAndQuery, StringComparison.InvariantCultureIgnoreCase) > -1)
+                            {
+                                return url.Replace(webUrlPathAndQuery, "{site}");
+                            }
                         }
                     }
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -51,34 +51,26 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     return url.Substring(url.IndexOf("/_catalogs/theme", StringComparison.InvariantCultureIgnoreCase)).Replace("/_catalogs/theme", "{themecatalog}");
                 }
+
                 if (url.IndexOf("/_catalogs/masterpage", StringComparison.InvariantCultureIgnoreCase) > -1)
                 {
                     return url.Substring(url.IndexOf("/_catalogs/masterpage", StringComparison.InvariantCultureIgnoreCase)).Replace("/_catalogs/masterpage", "{masterpagecatalog}");
                 }
+
+                Uri uri;
+                if (Uri.TryCreate(webUrl, UriKind.Absolute, out uri))
+                {
+                    if (uri.PathAndQuery != "/")
+                    {
+                        webUrl = HttpUtility.UrlDecode(uri.PathAndQuery);
+                    }
+                }
+
                 if (url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase) > -1)
                 {
                     return url.Replace(webUrl, "{site}");
                 }
-                if (url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase) > -1)
-                {
-                    return url.Substring(url.IndexOf(webUrl, StringComparison.InvariantCultureIgnoreCase)).Replace(webUrl, "{site}");
-                }
-                else
-                {
-                    Uri uri;
-                    if (Uri.TryCreate(webUrl, UriKind.Absolute, out uri))
-                    {
-                        if (uri.PathAndQuery != "/")
-                        {
-                            var webUrlPathAndQuery = HttpUtility.UrlDecode(uri.PathAndQuery);
-                            if (url.IndexOf(webUrlPathAndQuery, StringComparison.InvariantCultureIgnoreCase) > -1)
-                            {
-                                return url.Replace(webUrlPathAndQuery, "{site}");
-                            }
-                        }
-                    }
-                }
-               
+
                 // nothing to tokenize...
                 return url;
             }


### PR DESCRIPTION
Changed Tokenize back to allow tokenization of propertybag values (no only urls).

Eg.
Within "ObjectPropertyBagEntry.ExtractObjects" propertybag values are tokenized.

                foreach (PropertyBagEntry propbagEntry in template.PropertyBagEntries)
                {
                    propbagEntry.Value = Tokenize(propbagEntry.Value, web.ServerRelativeUrl);
                }