### PR TITLE
Loggingfixes

### DIFF
--- a/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
+++ b/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace OfficeDevPnP.Core.Diagnostics
 {
@@ -97,8 +93,6 @@ namespace OfficeDevPnP.Core.Diagnostics
                 });
             }
         }
-
-
         public static void Error(Exception ex, string source, string message, params object[] args)
         {
             InitializeLogger();
@@ -112,7 +106,6 @@ namespace OfficeDevPnP.Core.Diagnostics
                 });
             }
         }
-
         public static void Error(LogEntry logEntry)
         {
             InitializeLogger();
@@ -136,8 +129,6 @@ namespace OfficeDevPnP.Core.Diagnostics
                 });
             }
         }
-
-
         public static void Info(Exception ex, string source, string message, params object[] args)
         {
             InitializeLogger();
@@ -151,7 +142,6 @@ namespace OfficeDevPnP.Core.Diagnostics
                 });
             }
         }
-
         public static void Info(LogEntry logEntry)
         {
             InitializeLogger();
@@ -167,7 +157,7 @@ namespace OfficeDevPnP.Core.Diagnostics
         public static void Warning(string source, string message, params object[] args)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Information || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(new LogEntry()
                 {
@@ -177,12 +167,10 @@ namespace OfficeDevPnP.Core.Diagnostics
             }
         }
 
-
-
         public static void Warning(string source, Exception ex, string message, params object[] args)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Information || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(new LogEntry()
                 {
@@ -196,7 +184,7 @@ namespace OfficeDevPnP.Core.Diagnostics
         public static void Warning(LogEntry logEntry)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Information || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(logEntry);
             }

--- a/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
+++ b/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
@@ -104,7 +104,7 @@ namespace OfficeDevPnP.Core.Diagnostics
             InitializeLogger();
             if (_logLevel == LogLevel.Error || _logLevel == LogLevel.Debug)
             {
-                _logger.Info(new LogEntry()
+                _logger.Error(new LogEntry()
                 {
                     Message = string.Format(message, args),
                     Source = source,

--- a/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
+++ b/Core/OfficeDevPnP.Core/Diagnostics/Log.cs
@@ -167,7 +167,7 @@ namespace OfficeDevPnP.Core.Diagnostics
         public static void Warning(string source, string message, params object[] args)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Information)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(new LogEntry()
                 {
@@ -182,7 +182,7 @@ namespace OfficeDevPnP.Core.Diagnostics
         public static void Warning(string source, Exception ex, string message, params object[] args)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Information)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(new LogEntry()
                 {
@@ -196,7 +196,7 @@ namespace OfficeDevPnP.Core.Diagnostics
         public static void Warning(LogEntry logEntry)
         {
             InitializeLogger();
-            if (_logLevel == LogLevel.Debug)
+            if (_logLevel == LogLevel.Warning || _logLevel == LogLevel.Debug)
             {
                 _logger.Warning(logEntry);
             }


### PR DESCRIPTION
The Log.cs class contains some apparent copy/paste bugs. For example that the Warning methods aren't checking if the logLevel is actually warning or debug, but only debug.. Or that the same method checks for logLevel "information" rather than "debug" (there's a separate method for logLevel == Information)..

Also fixed a bug where one of the Error methods were incorrectly calling .Info() instead of .Error().