### PR TITLE
TokenParser public

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -8,7 +8,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    internal class TokenParser
+    public class TokenParser
     {
         public Web _web;
 


### PR DESCRIPTION
Make TokenParser class public so it can be used in external providers to parse external files (e.g. web part definitions etc.)