### PR TITLE
Removing validation for PublishingWeb

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListRatingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListRatingExtensions.cs
@@ -45,7 +45,8 @@ namespace Microsoft.SharePoint.Client
             //  only process publishing web
             if (!list.ParentWeb.IsPublishingWeb())
             {
-                throw new Exception("Not publishing web");
+                // Should not throw an Exception in O365
+                //throw new Exception("Not publishing web");
                 ////_logger.WriteWarning("Is publishing site : No");
             }
 


### PR DESCRIPTION
On O365 an List that has been created using CSOM (in Hostweb) will end up throwing this error when trying to enable Ratings. 

But there seem to be no problem in creating Ratings in that list. So removing this Exception (maybe a Warning would be nice or an additional Parameter to ignore this) just makes it work.