### PR TITLE
Removed redundant method call GetWebTemplate()

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -1040,8 +1040,6 @@ namespace Microsoft.SharePoint.Client
         public static ProvisioningTemplate GetProvisioningTemplate(this Web web)
         {
             ProvisioningTemplateCreationInformation creationInfo = new ProvisioningTemplateCreationInformation(web);
-            // Load the base template which will be used for the comparison work
-            creationInfo.BaseTemplate = web.GetBaseTemplate();
 
             return new SiteToTemplateConversion().GetRemoteTemplate(web, creationInfo);
         }


### PR DESCRIPTION
There is redundant method call (GetWebTemplate()) in the extension 
GetProvisioningTemplate(this Web web).
This method already called in the in the constructor of the class "ProvisioningTemplateCreationInformation"