### PR TITLE
PageExtensions.AddWikiPage: removed hardcoded url and handle existing page

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
@@ -864,7 +864,14 @@ namespace Microsoft.SharePoint.Client
                 web.Context.Load(newpage);
                 web.Context.ExecuteQueryRetry();
 
-                wikiPageUrl = UrlUtility.Combine("sitepages", wikiPageName);
+                wikiPageUrl = newpage.ServerRelativeUrl;
+            }
+            else
+            {
+                web.Context.Load(currentPageFile, s => s.ServerRelativeUrl);
+                web.Context.ExecuteQueryRetry();
+
+                wikiPageUrl = currentPageFile.ServerRelativeUrl;
             }
 
             return wikiPageUrl;


### PR DESCRIPTION

- Removed hard coded URL path "sitepages"
- Return of server relative URL instead list relative URL
- Return site relative URL if page already exists