### PR TITLE
Modified SharePoint connector to use web root folder rather than list folder when container is not supplied 

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Connectors/ConnectorSharePointTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Connectors/ConnectorSharePointTests.cs
@@ -26,6 +26,8 @@ namespace OfficeDevPnP.Core.Tests.Framework.Connectors
             // SharePoint setup
             using (ClientContext cc = TestCommon.CreateClientContext())
             {
+                cc.Web.RootFolder.UploadFile("TestDefault.aspx", @".\resources\testdefault.aspx", true);
+
                 if (!cc.Web.ListExists(testContainer))
                 {
                     List list = cc.Web.CreateDocumentLibrary(testContainer);
@@ -58,6 +60,10 @@ namespace OfficeDevPnP.Core.Tests.Framework.Connectors
             // SharePoint setup
             using (ClientContext cc = TestCommon.CreateClientContext())
             {
+                var file = cc.Web.RootFolder.GetFile("TestDefault.aspx");
+                file.DeleteObject();
+                cc.ExecuteQueryRetry();
+
                 if (cc.Web.ListExists(testContainer))
                 {
                     List list = cc.Web.GetListByTitle(testContainer);
@@ -307,6 +313,47 @@ namespace OfficeDevPnP.Core.Tests.Framework.Connectors
             }
 
             // file will be deleted at end of test 
+        }
+
+        /// <summary>
+        /// Pass the connection information as parameters
+        /// Get a file as string from passed SharePoint url
+        /// </summary>
+        [TestMethod]
+        public void SharePointConnectorGetFileFromWebRootFolder()
+        {
+            SharePointConnector spConnector = new SharePointConnector();
+            spConnector.Parameters.Add(SharePointConnector.CONNECTIONSTRING, TestCommon.DevSiteUrl);
+            spConnector.Parameters.Add(SharePointConnector.CLIENTCONTEXT, TestCommon.CreateClientContext());
+
+            string file = spConnector.GetFile("TestDefault.aspx");
+            Assert.IsNotNull(file);
+        }
+
+        /// <summary>
+        /// Delete file from default container
+        /// </summary>
+        [TestMethod]
+        public void SharePointConnectorDeleteFromWebRootFolder()
+        {
+            SharePointConnector spConnector = new SharePointConnector();
+            spConnector.Parameters.Add(SharePointConnector.CONNECTIONSTRING, TestCommon.DevSiteUrl);
+            spConnector.Parameters.Add(SharePointConnector.CLIENTCONTEXT, TestCommon.CreateClientContext());
+
+            // upload file
+            using (var fileStream = System.IO.File.OpenRead(@".\resources\testdefault.aspx"))
+            {
+                spConnector.SaveFileStream("blabla.aspx", string.Empty, fileStream);
+            }
+
+            // delete the file
+            spConnector.DeleteFile("blabla.aspx");
+
+            // read the file
+            using (var bytes = spConnector.GetFileStream("blabla.aspx"))
+            {
+                Assert.IsNull(bytes);
+            }
         }
         #endregion
     }

--- a/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -408,6 +408,10 @@
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-Sample-02.xml" />
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-Valid-XInclude-01.xml" />
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-XInclude-PropertyBags.xml" />
+    <Content Include="Resources\TestDefault.aspx">
+      <SubType>ASPXCodeBehind</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\UpdateTermSet.csv" />
   </ItemGroup>
   <ItemGroup>

--- a/Core/OfficeDevPnP.Core.Tests/Resources/TestDefault.aspx
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/TestDefault.aspx
@@ -1,0 +1,35 @@
+﻿<%@ Assembly Name="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c"%> 
+<%@ Import Namespace="Microsoft.SharePoint.WebPartPages" %> <%@ Register Tagprefix="SharePoint" Namespace="Microsoft.SharePoint.WebControls" Assembly="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %> <%@ Register Tagprefix="Utilities" Namespace="Microsoft.SharePoint.Utilities" Assembly="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %> <%@ Import Namespace="Microsoft.SharePoint" %> <%@ Assembly Name="Microsoft.Web.CommandUI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
+<%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
+
+<%@ Page Language="C#" MasterPageFile="~masterurl/default.master" Inherits="Microsoft.SharePoint.WebPartPages.WebPartPage,Microsoft.SharePoint,Version=15.0.0.0,Culture=neutral,PublicKeyToken=71e9bce111e9429c" %>
+
+<asp:Content ContentPlaceHolderId="PlaceHolderPageTitle" runat="server">
+	<SharePoint:ProjectProperty Property="Title" runat="server"/>
+</asp:Content>
+
+<asp:Content ContentPlaceHolderId="PlaceHolderPageTitleInTitleArea" runat="server">
+	<SharePoint:ProjectProperty Property="Title" runat="server"/>
+</asp:Content>
+
+<asp:Content ContentPlaceHolderID="PlaceHolderPageDescription" runat="server">
+	<SharePoint:ProjectProperty Property="Description" runat="server"/>
+</asp:Content>
+
+<asp:Content ContentPlaceHolderID="PlaceHolderMain" runat="server">
+	<div class="landing-page">
+        <SharePoint:FormDigest runat="server"/>
+
+	    <table class="cols-2">
+		    <tr>
+			    <td class="col-left">
+				    <WebPartPages:WebPartZone runat="server" ID="wpzMain" Title="Main" PartChromeType="TitleOnly" />
+			    </td>
+			    <td class="col-right">
+                    <WebPartPages:WebPartZone runat="server" ID="wpzRight" Title="Right" PartChromeType="TitleOnly" />
+			    </td>
+		    </tr>
+	    </table>
+    </div>
+
+</asp:Content>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileConnectorBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileConnectorBase.cs
@@ -144,7 +144,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             }
         }
 
-        internal string GetContainer()
+        virtual internal string GetContainer()
         {
             if (this.Parameters.ContainsKey(CONTAINER))
             {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -52,6 +52,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+
             this.AddParameter(CLIENTCONTEXT, clientContext);
             this.AddParameterAsString(CONNECTIONSTRING, connectionString);
             this.AddParameterAsString(CONTAINER, container);
@@ -103,8 +104,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 foreach (var listItem in listItems)
                 {
                     result.Add(listItem.FieldValues["FileLeafRef"].ToString());
-
-
                 }
             }
 
@@ -132,11 +131,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             if (String.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException("fileName");
-            }
-
-            if (String.IsNullOrEmpty(container))
-            {
-                throw new ArgumentException("container");
             }
 
             string result = null;
@@ -187,11 +181,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw new ArgumentException("fileName");
             }
 
-            if (String.IsNullOrEmpty(container))
-            {
-                throw new ArgumentException("container");
-            }
-
             return GetFileFromStorage(fileName, container);
         }
 
@@ -217,30 +206,37 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
                 {
-                    List list = cc.Web.GetListByUrl(GetDocumentLibrary(container));
+                    Folder spFolder;
 
-                    string folders = GetFolders(container);
-
-                    Folder spFolder = null;
-
-                    if (folders.Length == 0)
+                    if (!string.IsNullOrEmpty(container))
                     {
-                        spFolder = list.RootFolder;
+                        List list = cc.Web.GetListByUrl(GetDocumentLibrary(container));
+
+                        string folders = GetFolders(container);
+
+                        if (folders.Length == 0)
+                        {
+                            spFolder = list.RootFolder;
+                        }
+                        else
+                        {
+                            spFolder = list.RootFolder;
+                            string[] parts = container.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
+                            for (int i = 1; i < parts.Length; i++)
+                            {
+                                var prevFolder = spFolder;
+                                spFolder = spFolder.ResolveSubFolder(parts[i]);
+
+                                if (spFolder == null)
+                                {
+                                    spFolder = prevFolder.CreateFolder(parts[i]);
+                                }
+                            }
+                        }
                     }
                     else
                     {
-                        spFolder = list.RootFolder;
-                        string[] parts = container.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
-                        for (int i = 1; i < parts.Length; i++)
-                        {
-                            var prevFolder = spFolder;
-                            spFolder = spFolder.ResolveSubFolder(parts[i]);
-
-                            if (spFolder == null)
-                            {
-                                spFolder = prevFolder.CreateFolder(parts[i]);
-                            }
-                        }
+                        spFolder = cc.Web.RootFolder;
                     }
 
                     spFolder.UploadFile(fileName, stream, true);
@@ -274,29 +270,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
                 {
-                    List list = cc.Web.GetListByUrl(GetDocumentLibrary(container));
-
-                    string folders = GetFolders(container);
-
-                    Folder spFolder = null;
-
-                    if (folders.Length == 0)
-                    {
-                        spFolder = list.RootFolder;
-                    }
-                    else
-                    {
-                        spFolder = list.RootFolder;
-                        string[] parts = container.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
-                        for (int i = 1; i < parts.Length; i++)
-                        {
-                            spFolder = spFolder.ResolveSubFolder(parts[i]);
-                        }
-                    }
-
-                    spFolder.EnsureProperties(f => f.ServerRelativeUrl);
-
-                    var fileServerRelativeUrl = UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
+                    string fileServerRelativeUrl = GetFileServerRelativeUrl(cc, fileName, container);
                     File file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
                     cc.Load(file);
                     cc.ExecuteQueryRetry();
@@ -336,6 +310,45 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         #endregion
 
         #region Private Methods
+        private string GetFileServerRelativeUrl(ClientContext cc, string fileName, string container)
+        {
+            Folder spFolder;
+            if (!string.IsNullOrEmpty(container))
+            {
+                List list = cc.Web.GetListByUrl(GetDocumentLibrary(container));
+                string folders = GetFolders(container);
+
+                if (folders.Length == 0)
+                {
+                    spFolder = list.RootFolder;
+                }
+                else
+                {
+                    spFolder = list.RootFolder;
+                    string[] parts = container.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
+
+                    int startFrom = 1;
+                    if (parts[0].Equals("_catalogs", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        startFrom = 2;
+                    }
+
+                    for (int i = startFrom; i < parts.Length; i++)
+                    {
+                        spFolder = spFolder.ResolveSubFolder(parts[i]);
+                    }
+                }
+            }
+            else
+            {
+                spFolder = cc.Web.RootFolder;
+            }
+
+            spFolder.EnsureProperties(f => f.ServerRelativeUrl);
+
+            return UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
+        }
+
         private MemoryStream GetFileFromStorage(string fileName, string container)
         {
 
@@ -343,37 +356,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
                 {
-                    List list = cc.Web.GetListByUrl(GetDocumentLibrary(container));
-                    string folders = GetFolders(container);
-
-                    File file = null;
-                    Folder spFolder = null;
-
-                    if (folders.Length == 0)
-                    {
-                        spFolder = list.RootFolder;
-                    }
-                    else
-                    {
-                        spFolder = list.RootFolder;
-                        string[] parts = container.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
-
-                        int startFrom = 1;
-                        if (parts[0].Equals("_catalogs", StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            startFrom = 2;
-                        }
-
-                        for (int i = startFrom; i < parts.Length; i++)
-                        {
-                            spFolder = spFolder.ResolveSubFolder(parts[i]);
-                        }
-                    }
-
-                    spFolder.EnsureProperties(f => f.ServerRelativeUrl);
-                    
-                    var fileServerRelativeUrl = UrlUtility.Combine(spFolder.ServerRelativeUrl, fileName);
-                    file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
+                    string fileServerRelativeUrl = GetFileServerRelativeUrl(cc, fileName, container);
+                    var file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
                     cc.Load(file);
                     cc.ExecuteQueryRetry();
                     if (file.Exists)
@@ -390,10 +374,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                         stream.Position = 0;
                         return stream;
                     }
-                    else
-                    {
-                        throw new Exception("File not found");
-                    }
+
+                    throw new Exception("File not found");
                 }
             }
             catch (Exception ex)
@@ -455,8 +437,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw new Exception("No clientcontext specified");
             }
         }
+
         #endregion
 
+        internal override string GetContainer()
+        {
+            if (this.Parameters.ContainsKey(CONTAINER))
+            {
+                return this.Parameters[CONTAINER].ToString();
+            }
+            return string.Empty;
+        }
 
     }
 }


### PR DESCRIPTION
Modified SharePoint connector to use web root folder rather than list folder when container is not supplied.

Addresses issue when generating a template using the provisioning engine from a site where the welcome page is for example default.aspx in site root folder rather than a page in a list.