### PR TITLE
Added GetPagesLibrary method to Web extensions

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
@@ -155,6 +155,24 @@ namespace Microsoft.SharePoint.Client.Tests
         }
         #endregion
 
+        [TestMethod()]
+        public void GetPagesLibraryTest()
+        {
+            const string publishingWebFeatureId = "22a9ef51-737b-4ff2-9346-694633fe4416";
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                if (!clientContext.Web.IsFeatureActive(new Guid(publishingWebFeatureId)))
+                {
+                    Assert.Inconclusive("Can't execute GetPagesLibraryTest on a web without activated Publishing feature.");
+                }
+
+                var web = clientContext.Web;
+                var pages = web.GetPagesLibrary();
+
+                Assert.IsNotNull(pages);
+            }
+        }
+
         #region Default value tests
         [TestMethod()]
         public void SetDefaultColumnValuesTest()
@@ -190,6 +208,5 @@ namespace Microsoft.SharePoint.Client.Tests
             }
         }
         #endregion
-
     }
 }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -1,16 +1,17 @@
-﻿using System;
+﻿using Microsoft.SharePoint.Client.Taxonomy;
+using Microsoft.SharePoint.Client.Utilities;
+using Microsoft.SharePoint.Client.WebParts;
+using OfficeDevPnP.Core;
+using OfficeDevPnP.Core.Diagnostics;
+using OfficeDevPnP.Core.Entities;
+using OfficeDevPnP.Core.Enums;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
-using Microsoft.SharePoint.Client.Taxonomy;
-using OfficeDevPnP.Core;
-using OfficeDevPnP.Core.Entities;
-using OfficeDevPnP.Core.Enums;
-using Microsoft.SharePoint.Client.WebParts;
-using OfficeDevPnP.Core.Diagnostics;
 
 namespace Microsoft.SharePoint.Client
 {
@@ -728,6 +729,33 @@ namespace Microsoft.SharePoint.Client
             }
 
             return foundList;
+        }
+
+        /// <summary>
+        /// Gets the publishing pages library of the web.
+        /// </summary>
+        /// <param name="web">The web.</param>
+        /// <returns>The publishing pages library. Returns null if library was not found.</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// Could not load pages library URL name from 'cmscore' resources file.
+        /// </exception>
+        public static List GetPagesLibrary(this Web web)
+        {
+            if (web == null) throw new ArgumentNullException("web");
+
+            var context = web.Context;
+            int language = (int)web.EnsureProperty(w => w.Language);
+
+            var result = Utility.GetLocalizedString(context, "$Resources:List_Pages_UrlName", "cmscore", language);
+            context.ExecuteQueryRetry();
+            string pagesLibraryName = result.Value;
+
+            if (string.IsNullOrEmpty(pagesLibraryName))
+            {
+                throw new InvalidOperationException("Could not load pages library URL name from 'cmscore' resources file.");
+            }
+ 
+            return web.GetListByUrl(pagesLibraryName) ?? web.GetListByTitle(pagesLibraryName);
         }
 
         #region List Permissions

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
@@ -1113,20 +1113,12 @@ namespace Microsoft.SharePoint.Client
                   : new ArgumentException(CoreResources.Exception_Message_EmptyString_Arg, "fileLeafRef");
             }
 
-            ClientContext context = web.Context as ClientContext;
-
-            // Get the language agnostic "Pages" library name
-            context.Load(web, l => l.Language);
+            var context = web.Context as ClientContext;
+            List pages = web.GetPagesLibrary();
+            context.Load(pages);
             context.ExecuteQueryRetry();
 
-            ClientResult<string> pagesLibraryName = Utility.GetLocalizedString(context, "$Resources:List_Pages_UrlName", "cmscore", (int)web.Language);
-            context.ExecuteQueryRetry();
-
-            List spList = web.Lists.GetByTitle(pagesLibraryName.Value);
-            context.Load(spList);
-            context.ExecuteQueryRetry();
-
-            if (spList != null && spList.ItemCount > 0)
+            if (pages != null && pages.ItemCount > 0)
             {
                 CamlQuery camlQuery = new CamlQuery();
                 camlQuery.ViewXml = string.Format(@"<View>  
@@ -1135,7 +1127,7 @@ namespace Microsoft.SharePoint.Client
                                                         </Query> 
                                                     </View>", fileLeafRef);
 
-                ListItemCollection listItems = spList.GetItems(camlQuery);
+                ListItemCollection listItems = pages.GetItems(camlQuery);
                 context.Load(listItems);
                 context.ExecuteQueryRetry();
 


### PR DESCRIPTION
I refactored the language independent code to get the "Pages" library into a specific extension method of the Web class.

In projects where you have to work with the Publishing functionalities on sites with different languages this can be a helpful method.

The extension method "GetPagesLibrary" has a separate integration test that will only be executed when the Publishing feature is activated on the targeted Web.
We could force to activate the feature in case it's not activated. But for now I decided to mark the test as inconclusive then.