### PR TITLE
fix for #104 site column not exists on adding to existing content type

### DIFF
--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -873,6 +873,15 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Field {0} exists not in website.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_ContentTypes_Field__0__not_exists {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_ContentTypes_Field__0__not_exists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Content Type {0} with ID {1} cannot be transformed into a DocumentSet.
         /// </summary>
         internal static string Provisioning_ObjectHandlers_ContentTypes_InvalidDocumentSet_Update_Request {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -909,4 +909,7 @@
   <data name="WebExtensions_RequestAccessEmailLimitExceeded" xml:space="preserve">
     <value>Request access email addresses exceed 255 characters. Skipping: {0}</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_ContentTypes_Field__0__not_exists" xml:space="preserve">
+    <value>Field {0} exists not in website</value>
+  </data>
 </root>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -974,6 +974,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             createdList.AddContentTypeToListById(ctBinding.ContentTypeId, searchContentTypeInSiteHierarchy: true);
                         }
+                        else
+                        {
+                            foreach (var ct in contentTypesToRemove.AsEnumerable().Where(ct => (ct.Name == name )))
+                            {
+                                contentTypesToRemove.Remove(ct);
+                                break;
+                            }
+                        }
                         if (ctBinding.Default)
                         {
                             defaultCtBinding = ctBinding;
@@ -998,8 +1006,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     if (shouldDelete)
                     {
-                        ct.DeleteObject();
+                        web.Context.Load(createdList.ContentTypes);
                         web.Context.ExecuteQueryRetry();
+                        if (createdList.ContentTypes != null && createdList.ContentTypes.Count > 1)
+                        {
+                            ct.DeleteObject();
+                            web.Context.ExecuteQueryRetry();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
fix with check for existing field, if not - log for debug and throw an error, with the same description like the debug log, without description the bug in the pnp:templatexml is not findable for the end user, using powershell or any adapted sample code