### PR TITLE
Fix: DocumentTemplate property of ContentTypes would not be set on initial deployment

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -258,8 +258,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             //In this case the new Content Type has all field of the original Content Type and missing fields 
             //will be added at the end. To fix this issue we ordering the fields once more.
             createdCT.FieldLinks.Reorder(templateContentType.FieldRefs.Select(fld => fld.Name).ToArray());
-            createdCT.Update(true);
-            web.Context.ExecuteQueryRetry();
 
             createdCT.ReadOnly = templateContentType.ReadOnly;
             createdCT.Hidden = templateContentType.Hidden;
@@ -280,6 +278,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 createdCT.DisplayFormUrl = templateContentType.DisplayFormUrl;
             }
+
+            createdCT.Update(true);
+            web.Context.ExecuteQueryRetry();
 
             // If the CT is a DocumentSet
             if (templateContentType.DocumentSetTemplate != null)


### PR DESCRIPTION
Setting DocumentTemplate does not work currently for initial deployment in the current implementation due to the content type not being updated _after_ setting the documenttemplate property. This PR fixes that issue.

Note: in the current implementation (pre this PR) running a template twice or more on a site will update the DocumentTemplate property, this is due to the UpdateContentType handling things correctly.

I.E. to test this fix you need to try on a fresh site collection 