### PR TITLE
Keep resource tokens while provisioning fields

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -765,7 +765,7 @@ namespace Microsoft.SharePoint.Client
 
             // Ensure other content-type properties
             contentType.EnsureProperties(c => c.Id, c => c.SchemaXml, c => c.FieldLinks.Include(fl => fl.Id, fl => fl.Required, fl => fl.Hidden));
-            field.EnsureProperties(f => f.Id, f => f.SchemaXml);
+            field.EnsureProperties(f => f.Id, f => f.SchemaXmlWithResourceTokens);
 
             Log.Info(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_AddField0ToContentType1, field.Id, contentType.Id);
 
@@ -774,7 +774,7 @@ namespace Microsoft.SharePoint.Client
             var flink = contentType.FieldLinks.FirstOrDefault(fld => fld.Id == field.Id);
             if (flink == null)
             {
-                XElement fieldElement = XElement.Parse(field.SchemaXml);
+                XElement fieldElement = XElement.Parse(field.SchemaXmlWithResourceTokens);
                 fieldElement.SetAttributeValue("AllowDeletion", "TRUE"); // Default behavior when adding a field to a CT from the UI.
                 field.SchemaXml = fieldElement.ToString();
                 var fldInfo = new FieldLinkCreationInformation();

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -458,9 +458,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private static void CreateFieldRef(ListInfo listInfo, Field field, FieldRef fieldRef)
         {
-            XElement element = XElement.Parse(field.SchemaXml);
+			field.EnsureProperty(f => f.SchemaXmlWithResourceTokens);
+			XElement element = XElement.Parse(field.SchemaXmlWithResourceTokens);
 
-            element.SetAttributeValue("AllowDeletion", "TRUE");
+			element.SetAttributeValue("AllowDeletion", "TRUE");
 
             field.SchemaXml = element.ToString();
 
@@ -533,12 +534,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private void UpdateField(ClientObject web, ListInfo listInfo, Guid fieldId, XElement templateFieldElement, Field existingField, PnPMonitoredScope scope, TokenParser parser, string originalFieldXml)
         {
-            web.Context.Load(existingField, f => f.SchemaXml);
-            web.Context.ExecuteQueryRetry();
+			web.Context.Load(existingField, f => f.SchemaXml, f => f.SchemaXmlWithResourceTokens);
+			web.Context.ExecuteQueryRetry();
 
-            var existingFieldElement = XElement.Parse(existingField.SchemaXml);
-
-            var equalityComparer = new XNodeEqualityComparer();
+			var existingFieldElement = XElement.Parse(existingField.SchemaXmlWithResourceTokens);
+			var equalityComparer = new XNodeEqualityComparer();
 
             // Is field different in template?
             if (equalityComparer.GetHashCode(existingFieldElement) != equalityComparer.GetHashCode(templateFieldElement))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -461,7 +461,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 			field.EnsureProperty(f => f.SchemaXmlWithResourceTokens);
 			XElement element = XElement.Parse(field.SchemaXmlWithResourceTokens);
 
-			element.SetAttributeValue("AllowDeletion", "TRUE");
+            element.SetAttributeValue("AllowDeletion", "TRUE");
 
             field.SchemaXml = element.ToString();
 
@@ -534,11 +534,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private void UpdateField(ClientObject web, ListInfo listInfo, Guid fieldId, XElement templateFieldElement, Field existingField, PnPMonitoredScope scope, TokenParser parser, string originalFieldXml)
         {
-			web.Context.Load(existingField, f => f.SchemaXml, f => f.SchemaXmlWithResourceTokens);
-			web.Context.ExecuteQueryRetry();
+            web.Context.Load(existingField, f => f.SchemaXml, f => f.SchemaXmlWithResourceTokens);
+            web.Context.ExecuteQueryRetry();
 
-			var existingFieldElement = XElement.Parse(existingField.SchemaXmlWithResourceTokens);
-			var equalityComparer = new XNodeEqualityComparer();
+            var existingFieldElement = XElement.Parse(existingField.SchemaXmlWithResourceTokens);
+
+            var equalityComparer = new XNodeEqualityComparer();
 
             // Is field different in template?
             if (equalityComparer.GetHashCode(existingFieldElement) != equalityComparer.GetHashCode(templateFieldElement))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
@@ -64,7 +64,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var webId = string.Empty;
 
                     var field = rootWeb.Fields.GetById(fieldId);
-                    rootWeb.Context.Load(field, f => f.SchemaXml);
+                    rootWeb.Context.Load(field, f => f.SchemaXml, f => f.SchemaXmlWithResourceTokens);
                     rootWeb.Context.ExecuteQueryRetry();
 
                     List sourceList = FindSourceList(listIdentifier, web, rootWeb);
@@ -104,7 +104,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         try
                         {
                             var field = createdList.Fields.GetById(fieldId);
-                            web.Context.Load(field, f => f.SchemaXml);
+                            web.Context.Load(field, f => f.SchemaXml, f => f.SchemaXmlWithResourceTokens);
                             web.Context.ExecuteQueryRetry();
 
                             List sourceList = FindSourceList(listIdentifier, web, rootWeb);
@@ -160,7 +160,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             var isDirty = false;
 
-            var existingFieldElement = XElement.Parse(field.SchemaXml);
+            var existingFieldElement = XElement.Parse(field.SchemaXmlWithResourceTokens);
 
             isDirty = UpdateFieldAttribute(existingFieldElement, "List", listGuid.ToString(), false);
 


### PR DESCRIPTION
Resource tokens are removed from field schema during provisioning since SchemaXml is used to read schema instead of SchemaXmlWithResourceTokens. It makes sense to keep those tokens from localization perspective. It would be also good to extract schema with resource token during template extraction.