### PR TITLE
Remove already existing fields before adding new ones to default view

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListRatingExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListRatingExtensions.cs
@@ -58,7 +58,8 @@ namespace Microsoft.SharePoint.Client
             else
             {
                 AddListFields();
-
+                // remove already existing fields from the default view to prevent duplicates
+                RemoveViewFields(); 
                 AddViewFields(experience);
             }
 


### PR DESCRIPTION

If SetRating() is called multiple times (eg. switching from none to "VotingExperience.Likes" to "VotingExperience,Rating") each time the fields are added to the view. Resulting in something like this:
http://ibin.co/2Y5QoWk8u5jS

Added removing already existing Fields (only in the view) before adding the new ones.