### PR TITLE
Fixes for Workflow duplication issues #323 and #429

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1330,25 +1330,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 else
                 {
-                    //var schemaXml = ParseFieldSchema(field.SchemaXml, lists); //not being used..
+                    var schemaXml = ParseFieldSchema(field.SchemaXml, lists);
                     var fieldElement = XElement.Parse(field.SchemaXml);
                     var listId = fieldElement.Attribute("List") != null ? fieldElement.Attribute("List").Value : null;
-
-                    //get field type
-                    var fieldType = fieldElement.Attribute("Type") != null ? fieldElement.Attribute("Type").Value : null;
-
-                    if (fieldType != null && fieldType == "Calculated")
-                    {
-                        var calcualtedField = (FieldCalculated)field;
-
-                        // update SchemaXml value with field formula value
-                        // SchemaXml value contains the Internal Column names but we need the Column Display Names when extracting or provisioning will fail
-                        if (fieldElement.Element("Formula") != null)
-                        {
-                            fieldElement.Element("Formula").Value = calcualtedField.Formula;
-                            field.SchemaXml = fieldElement.ToString();
-                        }
-                    }
 
                     if (listId == null)
                         list.Fields.Add((new Model.Field { SchemaXml = field.SchemaXml }));

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1330,9 +1330,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
                 else
                 {
-                    var schemaXml = ParseFieldSchema(field.SchemaXml, lists);
+                    //var schemaXml = ParseFieldSchema(field.SchemaXml, lists); //not being used..
                     var fieldElement = XElement.Parse(field.SchemaXml);
                     var listId = fieldElement.Attribute("List") != null ? fieldElement.Attribute("List").Value : null;
+
+                    //get field type
+                    var fieldType = fieldElement.Attribute("Type") != null ? fieldElement.Attribute("Type").Value : null;
+
+                    if (fieldType != null && fieldType == "Calculated")
+                    {
+                        var calcualtedField = (FieldCalculated)field;
+
+                        // update SchemaXml value with field formula value
+                        // SchemaXml value contains the Internal Column names but we need the Column Display Names when extracting or provisioning will fail
+                        if (fieldElement.Element("Formula") != null)
+                        {
+                            fieldElement.Element("Formula").Value = calcualtedField.Formula;
+                            field.SchemaXml = fieldElement.ToString();
+                        }
+                    }
 
                     if (listId == null)
                         list.Fields.Add((new Model.Field { SchemaXml = field.SchemaXml }));


### PR DESCRIPTION
Fixes for Workflow duplication issues #323 and #429

Added a check for existing Workflow Definitions and Subscriptions before adding them to stop duplication.
Included Subscription.Id and Subscription.Name property definitions when creating the Workflow Subscription as this fixes an issue where the workflow subscription is duplicated if it is re-published in SP Designer.