### PR TITLE
Fix for adding Wiki Home Page during creation

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -85,7 +85,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Pages_Creating_new_page__0_, url);
 
                             web.AddWikiPageByUrl(url);
-                            web.AddLayoutToWikiPage(page.Layout, url);
+                            if (page.Layout == WikiPageLayout.Custom)
+                            {
+                                web.AddLayoutToWikiPage(WikiPageLayout.OneColumn, url);
+                            }
+                            else {
+                                web.AddLayoutToWikiPage(page.Layout, url);
+                            }
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
This fixes an error where if the wiki page doesn't exist and the PageLayout is Custom it fails to create them, but running again will work. This was because the check for the Custom pagelayout wasn't included in the code block for non-existing wikipages and was present for the existing wiki pages.
