### PR TITLE
Adding Publishing Pages - Read only field fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -197,7 +197,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var targetField = parentList.Fields.GetByInternalNameOrTitle(propertyName);
                     targetField.EnsureProperties(f => f.TypeAsString, f => f.ReadOnlyField);
 
-                    if (true)  // !targetField.ReadOnlyField)
+                    if (!targetField.ReadOnlyField)
                     {
                         switch (propertyName.ToUpperInvariant())
                         {


### PR DESCRIPTION
Fix for checking if a field is not read only before trying to set the value when setting a files properties.

Not sure why this was previously commented out, but without this check we are unable to add a publishing page as it errors when trying to set a value on a read only field.