### PR TITLE
Added functionality: Convert folder to document set

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Utilities;
@@ -175,12 +174,10 @@ namespace Microsoft.SharePoint.Client
             list.EnsureProperties(l => l.ContentTypes.Include(c => c.StringId));
 
             var listItem = folder.ListItemAllFields;
-            list.Context.Load(listItem, f => f["ContentTypeId"]);
-            list.Context.ExecuteQueryRetry();
+            listItem.EnsureProperty(f => f["ContentTypeId"]);
 
             // If already a document set, just return the folder
-            if (listItem["ContentTypeId"].ToString().StartsWith(BuiltInContentTypeId.DocumentSet)) return folder;
-
+            if (listItem["ContentTypeId"].ToString() == BuiltInContentTypeId.Folder) return folder;
             listItem["ContentTypeId"] = BuiltInContentTypeId.DocumentSet;
 
             // Add missing properties            

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -170,11 +170,11 @@ namespace Microsoft.SharePoint.Client
         }
 
         private static Folder ConvertFolderToDocumentSetImplementation(this List list, Folder folder)
-        {            
+        {
             list.EnsureProperties(l => l.ContentTypes.Include(c => c.StringId));
-
+            folder.Context.Load(folder.ListItemAllFields, l => l["ContentTypeId"]);
+            folder.Context.ExecuteQueryRetry();
             var listItem = folder.ListItemAllFields;
-            listItem.EnsureProperty(f => f["ContentTypeId"]);
 
             // If already a document set, just return the folder
             if (listItem["ContentTypeId"].ToString() == BuiltInContentTypeId.Folder) return folder;


### PR DESCRIPTION
As a rule of thumb: one should always use document sets instead of folders. But if folders were used, whether by malicious users or (now) fired developers, you might want to convert them. 