### PR TITLE
Added Order for Webpart provisioning

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
@@ -215,6 +215,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     Title = webPart.WebPart.Title,
                     Row = (uint)webPart.WebPart.ZoneIndex,
+                    Order = (uint)webPart.WebPart.ZoneIndex,
                     Contents = webPartxml
                 };
 #if !CLIENTSDKV15


### PR DESCRIPTION
Although the template contained the order for the webparts it was not coming through when provisioning this was because it was not being set, so it has now been added