### PR TITLE
This is a propossed solution for issue #484

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -187,6 +187,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
 
+                bool publishFile = false;
+                string publishFileLevel = String.Empty;
+
                 // Loop through and detect changes first, then, check out if required and apply
                 foreach (var kvp in properties)
                 {
@@ -216,6 +219,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     }
                                     break;
                                 }
+                            case "_LEVEL":
+                                {
+                                    publishFile = true;
+                                    publishFileLevel = propertyValue;
+                                }
+                                break;
                             default:
                                 {
                                     switch (targetField.TypeAsString)
@@ -271,6 +280,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     file.ListItemAllFields.Update();
                     context.ExecuteQueryRetry();
+                }
+
+                if (publishFile)
+                {
+                    FileLevel level = (FileLevel)Enum.Parse(typeof(FileLevel), publishFileLevel);
+                    file.PublishFileToLevel(level);
                 }
             }
         }


### PR DESCRIPTION
That way you can add a File property node with name "_Level" and a string value like the FileLevel enum (Published, Draft, Checkout)
I guess the right way should be to add a new attribute to the pnp:File node, but that requires to change the PnP Schema.

Note: not sure why GitHub is detecting so many changes in the file. Just added: 190-191, 222-227, 285-289. Rest of the file is not touched.