### PR TITLE
Fix for #323 Workflows not provisioning correctly

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWorkflows.cs
@@ -245,7 +245,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             .Where(d => d.Key == "TaskListId" ||
                                         d.Key == "HistoryListId" ||
                                         d.Key == "SharePointWorkflowContext.Subscription.Id" ||
-                                        d.Key == "SharePointWorkflowContext.Subscription.Name"))
+                                        d.Key == "SharePointWorkflowContext.Subscription.Name" ||
+                                        d.Key == "CreatedBySPD"))
                         {
                             workflowSubscription.SetProperty(propertyDefinition.Key, parser.ParseString(propertyDefinition.Value));
                         }


### PR DESCRIPTION
We were experiencing this issue again for another site where the workflow subscriptions weren't correctly provisioned, now fixed by copying CreatedBySPD property definition value when creating the subscription