### PR TITLE
Upload files with encoded file names in XML

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -58,9 +58,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Files_Uploading_and_overwriting_existing_file__0_, file.Src);
                             checkedOut = CheckOutIfNeeded(web, targetFile);
 
-                            using (var stream = template.Connector.GetFileStream(file.Src))
+                            using (var stream = GetFileStream(template, file))
                             {
-                                targetFile = folder.UploadFile(template.Connector.GetFilenamePart(file.Src), stream, file.Overwrite);
+                                targetFile = UploadFile(template, file, folder, stream);
                             }
                         }
                         else
@@ -70,10 +70,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     else
                     {
-                        using (var stream = template.Connector.GetFileStream(file.Src))
+                        using (var stream = GetFileStream(template, file))
                         {
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_Files_Uploading_file__0_, file.Src);
-                            targetFile = folder.UploadFile(template.Connector.GetFilenamePart(file.Src), stream, file.Overwrite);
+                            targetFile = UploadFile(template, file, folder, stream);
                         }
 
                         checkedOut = CheckOutIfNeeded(web, targetFile);
@@ -125,6 +125,40 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 }
             }
             return parser;
+        }
+
+        private static File UploadFile(ProvisioningTemplate template, Model.File file, Microsoft.SharePoint.Client.Folder folder, Stream stream)
+        {
+            File targetFile = null;
+            var fileName = template.Connector.GetFilenamePart(file.Src);
+            try
+            {
+                targetFile = folder.UploadFile(fileName, stream, file.Overwrite);
+            }
+            catch (Exception)
+            {
+                //The file name might contain encoded characters that prevent upload. Decode it and try again.
+                fileName = WebUtility.UrlDecode(fileName);
+                targetFile = folder.UploadFile(fileName, stream, file.Overwrite);
+            }
+            return targetFile;
+        }
+
+        /// <summary>
+        /// Retrieves <see cref="Stream"/> from connector. If the file name contains special characters (e.g. "%20") and cannot be retrieved, a workaround will be performed
+        /// </summary>
+        private static Stream GetFileStream(ProvisioningTemplate template, Model.File file)
+        {
+            var fileName = file.Src;
+            var stream = template.Connector.GetFileStream(fileName);
+            if (stream == null)
+            {
+                //Decode the URL and try again
+                fileName = WebUtility.UrlDecode(fileName);
+                stream = template.Connector.GetFileStream(fileName);
+            }
+
+            return stream;
         }
 
         private static bool CheckOutIfNeeded(Web web, File targetFile)


### PR DESCRIPTION
Proposed fix for issue #514. The changed code will try to upload file as usual. If loading the file fails, the filename will be decoded (e.g. "%20" will be converted to a single space) and it will try to read the file with the new filename once more. If the upload fails, a similar workaround will be performed.