### PR TITLE
Configurable behavior for ObjectPersistTemplateInfo handler

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
@@ -18,11 +18,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         public ProvisioningProgressDelegate ProgressDelegate { get; set; }
         public ProvisioningMessagesDelegate MessagesDelegate { get; set; }
-
-        /// <summary>
-        /// If true, system propertybag entries that start with _, vti_, dlc_ etc. will be overwritten if overwrite = true on the PropertyBagEntry. If not true those keys will be skipped, regardless of the overwrite property of the entry.
-        /// </summary>
-        public bool OverwriteSystemPropertyBagValues { get; set; }
+		public bool PersistTemplateInfo { get; set; } = true;
+		/// <summary>
+		/// If true, system propertybag entries that start with _, vti_, dlc_ etc. will be overwritten if overwrite = true on the PropertyBagEntry. If not true those keys will be skipped, regardless of the overwrite property of the entry.
+		/// </summary>
+		public bool OverwriteSystemPropertyBagValues { get; set; }
 
         public Handlers HandlersToProcess
         {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -181,7 +181,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.PropertyBagEntries)) objectHandlers.Add(new ObjectPropertyBagEntry());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ExtensibilityProviders)) objectHandlers.Add(new ObjectExtensibilityHandlers());
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.WebSettings)) objectHandlers.Add(new ObjectWebSettings());
-                objectHandlers.Add(new ObjectPersistTemplateInfo());
+				if (provisioningInfo.PersistTemplateInfo)
+				{
+					objectHandlers.Add(new ObjectPersistTemplateInfo());
+				}
 
                 var tokenParser = new TokenParser(web, template);
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ExtensibilityProviders))


### PR DESCRIPTION
Hi,
Please make configurable behavior for applying ObjectPersistTemplateInfo provisioning handler. The point is ObjectPersistTemplateInfo writes to web's property bag so requires FullControl permissions to execute. So when you try to execute only those handlers that require less permissions (e.g. ObjectPages or ObjectFiles) you still need FullControl to apply the template.
This is just a proposal of implementation, feel free to implement it another way.
__
Br, Ivan