### PR TITLE
Implemented support for extracting multi-language resource values.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/UserResourceExtensions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/Extensions/UserResourceExtensions.cs
@@ -1,7 +1,12 @@
 ﻿using Microsoft.SharePoint.Client;
+using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Resources;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -11,6 +16,58 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
 #if !ONPREMISES
     internal static class UserResourceExtensions
     {
+        private static List<Tuple<string, int, string>> ResourceTokens = new List<Tuple<string, int, string>>();
+
+        public static ProvisioningTemplate SaveResourceValues(ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            var tempFolder = System.IO.Path.GetTempPath();
+
+            var languages = ResourceTokens.Select(t => t.Item2).Distinct();
+            foreach (int language in languages)
+            {
+                var resourceFileName = System.IO.Path.Combine(tempFolder, string.Format("{0}{1}.resx", creationInfo.ResourceFilePrefix, language));
+                if (System.IO.File.Exists(resourceFileName))
+                {
+                    // Read existing entries, if any
+                    using (ResXResourceReader resxReader = new ResXResourceReader(resourceFileName))
+                    {
+                        foreach (DictionaryEntry entry in resxReader)
+                        {
+                            // find if token is already there
+                            var existingToken = ResourceTokens.FirstOrDefault(t => t.Item1 == entry.Key.ToString() && t.Item2 == language);
+                            if (existingToken == null)
+                            {
+                                ResourceTokens.Add(new Tuple<string, int, string>(entry.Key.ToString(), language, entry.Value as string));
+                            }
+                        }
+                    }
+                }
+
+                var culture = new CultureInfo(language);
+
+                // Create new resource file
+                using (ResXResourceWriter resx = new ResXResourceWriter(resourceFileName))
+                {
+                    foreach (var token in ResourceTokens.Where(t => t.Item2 == language))
+                    {
+
+                        resx.AddResource(token.Item1, token.Item3);
+                    }
+                }
+
+                template.Localizations.Add(new Localization() { LCID = language, Name = culture.NativeName, ResourceFile = string.Format("{0}{1}.resx", creationInfo.ResourceFilePrefix, language) });
+
+                // Persist the file using the connector
+                using (FileStream stream = System.IO.File.Open(resourceFileName, FileMode.Open))
+                {
+                    creationInfo.FileConnector.SaveFileStream(string.Format("{0}{1}.resx", creationInfo.ResourceFilePrefix, language), stream);
+                }
+                // remove the temp resx file
+                System.IO.File.Delete(resourceFileName);
+            }
+            return template;
+        }
+
         public static bool SetUserResourceValue(this UserResource userResource, string tokenValue, TokenParser parser)
         {
             bool isDirty = false;
@@ -39,6 +96,29 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions
                 return false;
             }
         }
+
+        public static bool PersistResourceValue(UserResource userResource, string token, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            bool returnValue = false;
+            foreach (var language in template.SupportedUILanguages)
+            {
+                var culture = new CultureInfo(language.LCID);
+
+                var value = userResource.GetValueForUICulture(culture.Name);
+                userResource.Context.ExecuteQueryRetry();
+                if (!string.IsNullOrEmpty(value.Value))
+                {
+                    returnValue = true;
+                    ResourceTokens.Add(new Tuple<string, int, string>(token, language.LCID, value.Value));
+                    //resx.AddResource(token, value.Value);
+                }
+                //}
+            }
+
+            return returnValue;
+        }
     }
+
+
 #endif
 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -248,7 +248,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 createdCT.NameResource.SetUserResourceValue(templateContentType.Name, parser);
             }
-            if(templateContentType.Description.ContainsResourceToken())
+            if (templateContentType.Description.ContainsResourceToken())
             {
                 createdCT.DescriptionResource.SetUserResourceValue(templateContentType.Description, parser);
             }
@@ -354,7 +354,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     return template;
                 }
 
-                template.ContentTypes.AddRange(GetEntities(web, scope));
+                template.ContentTypes.AddRange(GetEntities(web, scope, creationInfo, template));
 
                 // If a base template is specified then use that one to "cleanup" the generated template model
                 if (creationInfo.BaseTemplate != null)
@@ -365,7 +365,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return template;
         }
 
-        private IEnumerable<ContentType> GetEntities(Web web, PnPMonitoredScope scope)
+        private IEnumerable<ContentType> GetEntities(Web web, PnPMonitoredScope scope, ProvisioningTemplateCreationInformation creationInfo, ProvisioningTemplate template)
         {
             var cts = web.ContentTypes;
             web.Context.Load(cts, ctCollection => ctCollection.IncludeWithDefaultProperties(ct => ct.FieldLinks));
@@ -400,6 +400,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         EditFormUrl = ct.EditFormUrl,
                         NewFormUrl = ct.NewFormUrl,
                     };
+
+                    if (creationInfo.PersistMultiLanguageResources)
+                    {
+                        if (UserResourceExtensions.PersistResourceValue(ct.NameResource, string.Format("ContentType_{0}_Title", ct.Name.Replace(" ", "_")), template, creationInfo))
+                        {
+                            newCT.Name = string.Format("{{res:ContentType_{0}_Title}}", ct.Name.Replace(" ", "_"));
+                        }
+                        if (UserResourceExtensions.PersistResourceValue(ct.DescriptionResource, string.Format("ContentType_{0}_Description", ct.Name.Replace(" ", "_")), template, creationInfo))
+                        {
+                            newCT.Description = string.Format("{{res:ContentType_{0}_Description}}", ct.Name.Replace(" ", "_"));
+                        }
+                    }
 
                     // If the Content Type is a DocumentSet
                     if (Microsoft.SharePoint.Client.DocumentSet.DocumentSetTemplate.IsChildOfDocumentSetContentType(web.Context, ct).Value ||

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -277,7 +277,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 foreach (var customAction in webCustomActions)
                 {
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_CustomActions_Adding_web_scoped_custom_action___0___to_template, customAction.Name);
-                    customActions.WebCustomActions.Add(CopyUserCustomAction(customAction));
+                    customActions.WebCustomActions.Add(CopyUserCustomAction(customAction, creationInfo,template));
                 }
 
                 // if this is a sub site then we're not creating entities for site collection scoped custom actions
@@ -286,7 +286,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     foreach (var customAction in siteCustomActions)
                     {
                         scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_CustomActions_Adding_site_scoped_custom_action___0___to_template, customAction.Name);
-                        customActions.SiteCustomActions.Add(CopyUserCustomAction(customAction));
+                        customActions.SiteCustomActions.Add(CopyUserCustomAction(customAction, creationInfo,template));
                     }
                 }
 
@@ -331,7 +331,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return template;
         }
 
-        private CustomAction CopyUserCustomAction(UserCustomAction userCustomAction)
+        private CustomAction CopyUserCustomAction(UserCustomAction userCustomAction, ProvisioningTemplateCreationInformation creationInfo, ProvisioningTemplate template)
         {
             var customAction = new CustomAction();
             customAction.Description = userCustomAction.Description;
@@ -351,6 +351,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             customAction.CommandUIExtension = !System.String.IsNullOrEmpty(userCustomAction.CommandUIExtension) ?
                 XElement.Parse(userCustomAction.CommandUIExtension) : null;
 
+            if (creationInfo.PersistMultiLanguageResources)
+            {
+                if (creationInfo.PersistMultiLanguageResources)
+                {
+                    if (UserResourceExtensions.PersistResourceValue(userCustomAction.TitleResource, string.Format("CustomAction_{0}_Title", userCustomAction.Title.Replace(" ", "_")), template, creationInfo))
+                    {
+                        var customActionTitle = string.Format("{{res:CustomAction_{0}_Title}}", userCustomAction.Title.Replace(" ", "_"));
+                        customAction.Title = customActionTitle;
+
+                    }
+                    if (UserResourceExtensions.PersistResourceValue(userCustomAction.DescriptionResource, string.Format("CustomAction_{0}_Description", userCustomAction.Title.Replace(" ", "_")), template, creationInfo))
+                    {
+                        var customActionDescription = string.Format("{{res:CustomAction_{0}_Description}}", userCustomAction.Title.Replace(" ", "_"));
+                        customAction.Description = customActionDescription;
+                    }
+                }
+            }
             return customAction;
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -416,6 +416,26 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         {
                             fieldXml = TokenizeFieldFormula(fieldXml);
                         }
+                        if(creationInfo.PersistMultiLanguageResources)
+                        {
+                            if (creationInfo.PersistMultiLanguageResources)
+                            {
+                                var fieldElement = XElement.Parse(fieldXml);
+                                if (UserResourceExtensions.PersistResourceValue(field.TitleResource, string.Format("Field_{0}_DisplayName", field.Title.Replace(" ", "_")), template, creationInfo))
+                                {
+                                    var fieldTitle = string.Format("{{res:Field_{0}_DisplayName}}", field.Title.Replace(" ", "_"));
+                                    fieldElement.SetAttributeValue("DisplayName", fieldTitle);
+                                }
+                                if (UserResourceExtensions.PersistResourceValue(field.DescriptionResource, string.Format("Field_{0}_Description", field.Title.Replace(" ", "_")), template, creationInfo))
+                                {
+                                    var fieldDescription = string.Format("{{res:Field_{0}_Description}}", field.Title.Replace(" ", "_"));
+                                    fieldElement.SetAttributeValue("Description", fieldDescription);
+                                }
+
+                                fieldXml = fieldElement.ToString();
+                            }
+
+                        }
                         template.SiteFields.Add(new Field() { SchemaXml = fieldXml });
                     }
                 }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -66,8 +66,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             }
                         }
                         // check if the List exists by url or by title
-                        var index = existingLists.FindIndex(x => x.Title.Equals(templateList.Title,StringComparison.OrdinalIgnoreCase) || x.RootFolder.ServerRelativeUrl.Equals(UrlUtility.Combine(serverRelativeUrl, templateList.Url),StringComparison.OrdinalIgnoreCase));
-                        
+                        var index = existingLists.FindIndex(x => x.Title.Equals(templateList.Title, StringComparison.OrdinalIgnoreCase) || x.RootFolder.ServerRelativeUrl.Equals(UrlUtility.Combine(serverRelativeUrl, templateList.Url), StringComparison.OrdinalIgnoreCase));
+
                         if (index == -1)
                         {
                             try
@@ -1231,13 +1231,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 ? siteList.MajorWithMinorVersionsLimit
                                 : 0
                     };
-
+                    if (creationInfo.PersistMultiLanguageResources)
+                    {
+                        if (UserResourceExtensions.PersistResourceValue(siteList.TitleResource, string.Format("List_{0}_Title", siteList.Title.Replace(" ", "_")), template, creationInfo))
+                        {
+                            list.Title = string.Format("{{res:List_{0}_Title}}", siteList.Title.Replace(" ", "_"));
+                        }
+                        if (UserResourceExtensions.PersistResourceValue(siteList.DescriptionResource, string.Format("List_{0}_Description", siteList.Title.Replace(" ", "_")), template, creationInfo))
+                        {
+                            list.Description = string.Format("{{res:List_{0}_Description}}", siteList.Title.Replace(" ", "_"));
+                        }
+                    }
 
                     list = ExtractContentTypes(web, siteList, contentTypeFields, list);
 
                     list = ExtractViews(siteList, list);
 
-                    list = ExtractFields(web, siteList, contentTypeFields, list, lists);
+                    list = ExtractFields(web, siteList, contentTypeFields, list, lists, creationInfo, template);
 
                     list.Security = siteList.GetSecurity();
 
@@ -1266,8 +1276,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     if (logCTWarning)
                     {
-                        scope.LogWarning("You are extracting a template from a subweb. List '{0}' refers to content types. Content types are not exported when extracting a template from a subweb", list.Title);
-                        WriteWarning(string.Format("You are extracting a template from a subweb. List '{0}' refers to content types. Content types are not exported when extracting a template from a subweb", list.Title), ProvisioningMessageType.Warning);
+                        scope.LogWarning("You are extracting a template from a subweb. List '{0}' refers to content types. Content types are not exported when extracting a template from a subweb", siteList.Title);
+                        WriteWarning(string.Format("You are extracting a template from a subweb. List '{0}' refers to content types. Content types are not exported when extracting a template from a subweb", siteList.Title), ProvisioningMessageType.Warning);
                     }
                 }
 
@@ -1346,7 +1356,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return list;
         }
 
-        private ListInstance ExtractFields(Web web, List siteList, List<FieldRef> contentTypeFields, ListInstance list, ListCollection lists)
+        private ListInstance ExtractFields(Web web, List siteList, List<FieldRef> contentTypeFields, ListInstance list, ListCollection lists, ProvisioningTemplateCreationInformation creationInfo, ProvisioningTemplate template)
         {
             var siteColumns = web.Fields;
             web.Context.Load(siteColumns, scs => scs.Include(sc => sc.Id));
@@ -1442,9 +1452,29 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         schemaXml = TokenizeFieldFormula(schemaXml);
                     }
 
+                    if (creationInfo.PersistMultiLanguageResources)
+                    {
+                        if (creationInfo.PersistMultiLanguageResources)
+                        {
+                            if (UserResourceExtensions.PersistResourceValue(field.TitleResource, string.Format("Field_{0}_DisplayName", field.Title.Replace(" ", "_")), template, creationInfo))
+                            {
+                                var fieldTitle = string.Format("{{res:Field_{0}_DisplayName}}", field.Title.Replace(" ", "_"));
+                                fieldElement.SetAttributeValue("DisplayName", fieldTitle);
+
+                            }
+                            if (UserResourceExtensions.PersistResourceValue(field.DescriptionResource, string.Format("Field_{0}_Description", field.Title.Replace(" ", "_")), template, creationInfo))
+                            {
+                                var fieldDescription = string.Format("{{res:Field_{0}_Description}}", field.Title.Replace(" ", "_"));
+                                fieldElement.SetAttributeValue("Description", fieldDescription);
+                            }
+
+                            schemaXml = fieldElement.ToString();
+                        }
+                    }
+
                     if (listId == null)
                     {
-                        list.Fields.Add((new Model.Field { SchemaXml = field.SchemaXml }));
+                        list.Fields.Add((new Model.Field { SchemaXml = schemaXml }));
                     }
                     else
                     {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -11,6 +11,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private ProvisioningTemplate baseTemplate;
         private FileConnectorBase fileConnector;
         private bool persistBrandingFiles = false;
+        private bool persistMultiLanguageResourceFiles = false;
+        private string resourceFilePrefix = "PnP_Resource_";
         private bool includeAllTermGroups = false;
         private bool includeSiteCollectionTermGroup = false;
         private bool includeSiteGroups = false;
@@ -57,6 +59,33 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             set
             {
                 this.fileConnector = value;
+            }
+        }
+
+        /// <summary>
+        /// Will create resource files named "PnP_Resource_[LCID].resx for every supported language. The files will be persisted to the location specified by the connector
+        /// </summary>
+        public bool PersistMultiLanguageResources
+        {
+            get
+            {
+                return this.persistMultiLanguageResourceFiles;
+            }
+            set
+            {
+                this.persistMultiLanguageResourceFiles = value;
+            }
+        }
+
+        public string ResourceFilePrefix
+        {
+            get
+            {
+                return this.resourceFilePrefix;
+            }
+            set
+            {
+                this.resourceFilePrefix = value;
             }
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -4,6 +4,7 @@ using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Diagnostics;
 using OfficeDevPnP.Core.Framework.Provisioning.Extensibility;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -116,6 +117,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         }
                     }
                 }
+
+                if (creationInfo.PersistMultiLanguageResources)
+                {
+                    template = UserResourceExtensions.SaveResourceValues(template, creationInfo);
+                }
+
                 return template;
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no ?
| New feature?    |  yes?
| New sample?      | no?
| Related issues?  | mentioned in #547

#### What's in this Pull Request?

Added functionality for exporting multi language resource files with the provisioning engine. Requires the PersistMultiLanguageResources property to be true on ProvisioningTemplateCreationInformation. Optionally set ResourceFilePrefix property on ProvisioningTemplateCreationInformation to a prefix other than "PnP_Resources_"