### PR TITLE
Ensure folder fix1

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -382,10 +382,9 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
 
             List containingList = null;
-            var searchFldUrl = folderServerRelativeUrl.EndsWith("/") ? folderServerRelativeUrl : folderServerRelativeUrl + "/";
             foreach (var list in listCollection)
             {
-                if (searchFldUrl.StartsWith(list.RootFolder.ServerRelativeUrl + "/", StringComparison.InvariantCultureIgnoreCase))
+                if (folderServerRelativeUrl.StartsWith(list.RootFolder.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
                     containingList = list;
                     break;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -374,7 +374,8 @@ namespace Microsoft.SharePoint.Client
                 web.Context.Load(web, w => w.ServerRelativeUrl);
                 web.Context.ExecuteQueryRetry();
             }
-            var folderServerRelativeUrl = web.ServerRelativeUrl + (web.ServerRelativeUrl.EndsWith("/") ? "" : "/") + webRelativeUrl;
+            
+            var folderServerRelativeUrl = UrlUtility.Combine(web.ServerRelativeUrl, webRelativeUrl, "/");
 
             // Check if folder is inside a list
             var listCollection = web.Lists;
@@ -384,7 +385,7 @@ namespace Microsoft.SharePoint.Client
             List containingList = null;
             foreach (var list in listCollection)
             {
-                if (folderServerRelativeUrl.StartsWith(list.RootFolder.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
+                if (folderServerRelativeUrl.StartsWith(UrlUtility.Combine(list.RootFolder.ServerRelativeUrl,"/"), StringComparison.InvariantCultureIgnoreCase))
                 {
                     containingList = list;
                     break;

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -382,9 +382,10 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
 
             List containingList = null;
+            var searchFldUrl = folderServerRelativeUrl.EndsWith("/") ? folderServerRelativeUrl : folderServerRelativeUrl + "/";
             foreach (var list in listCollection)
             {
-                if (folderServerRelativeUrl.StartsWith(list.RootFolder.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
+                if (searchFldUrl.StartsWith(list.RootFolder.ServerRelativeUrl + "/", StringComparison.InvariantCultureIgnoreCase))
                 {
                     containingList = list;
                     break;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes

#### What's in this Pull Request?

Bug desciption:
For example, we want to ensure folder path "AAAAAAAAA/BBB/C".
The website ("https://myportal.com/sites/test") contains two libraries: "AAA" and "AAAAAAAAA".
The root folder server relative path:
 for library "AAA": "/sites/test/AAA"
 for library "AAAAAAAAA": "/sites/test/AAAAAAAAA"
 
The variable folderServerRelativeUrl = "/sites/test/AAAAAAAAA/BBB/C" 

So, If we call the extension method web.EnsureFolderPath("AAAAAAAAA/BBB/C"), 
the folder may be created in the wrong library (with name "AAA"), because the string "/sites/test/AAAAAAAAA/BBB/C" starts with "/sites/test/AAA".
(as the result we have the incorrect folder server relative path: "/sites/test/AAA/AAAAAA/BBB/C")

This PR fix this bug. As a result, the path ensured properly: (https://myportal.com/sites/test/AAAAAAAAA/BBB/C)