### PR TITLE
IsSubSite not working when using admin context

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+Thank you for reporting an issue or suggesting an enhancement. We appreciate your feedback - to help the team to understand your needs, please complete the below template to ensure we have the necessary details to assist you. If you have a actual question, we would ask you to use PnP Yammer group at http://aka.ms/OfficeDevPnPYammer. Thanks!
+
+#### Which PnP repository to report the issue?
+- PnP Samples - https://github.com/OfficeDev/PnP
+- PnP Sites Core - https://github.com/OfficeDev/PnP-Sites-Core
+- PnP JS Core - https://github.com/OfficeDev/PnP-JS-Core
+- PnP PowerShell - https://github.com/OfficeDev/PnP-PowerShell
+
+*You can delete this section after you have confirmed target repository for your submission.*
+
+#### Category
+[ ] Bug
+[ ] Enhancement
+
+#### Environment
+[ ] Office 365 / SharePoint Online
+[ ] SharePoint 2016
+[ ] SharePoint 2013
+
+If SharePoint on-premises, what's exact CU version: 
+
+#### Expected or Desired Behavior
+_If you are reporting a bug, please describe the expected behavior. If you are suggesting an enhancement please
+describe thoroughly the enhancement, how it can be achieved, and expected benefit._
+
+#### Observed Behavior
+_If you are reporting a bug, please describe the behavior you expected to occur when performing the action. If you are making a suggestion, you can delete this section._
+
+#### Steps to Reproduce
+_If you are reporting a bug please describe the steps to reproduce the bug in sufficient detail to allow testing. Only way to fix things properly, is to have sufficient details to reproduce it. If you are making a suggestion, you can delete this section._
+
+#### Submission Guidelines
+_Delete this section after reading_
+- All suggestions or bugs are welcome, please let us know what's on your mind.
+- If you are reporting any issues around PnP Core Component, please reproduce the issue with latest release.
+- If you are reporting issue around PnP Provisioning Engine, please share the xml template, if possible.
+- If you are reporting an issue around any of the samples, please ensure that you have clear reference on the sample and possibly code file, which should be fixed.
+- If you have a general question, please use the [PnP Yammer Group](http://aka.ms/OfficeDevPnPYammer).
+- Remember to include sufficient details and context.
+- If you have multiple suggestions or bugs please submit them in seperate bugs so we can track resolution.
+
+Thanks for your contribution! Sharing is caring.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+| Q               | A
+| --------------- | ---
+| Bug fix?        | no - yes?
+| New feature?    | no - yes?
+| New sample?      | no - yes?
+| Related issues?  | fixes #X, partially #Y, mentioned in #Z
+
+#### What's in this Pull Request?
+
+Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
+
+
+#### Guidance
+*You can delete this section when you are submitting the pull request.* 
+* *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
+* *Please target your PR to Dev branch.*

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -264,19 +264,16 @@ namespace Microsoft.SharePoint.Client
         /// <returns>True is sub site, false otherwise</returns>
         public static bool IsSubSite(this Web web)
         {
-            Site site = (web.Context as ClientContext).Site;
-            var rootWeb = site.EnsureProperty(s => s.RootWeb);
+            web.EnsureProperty(w => w.ParentWeb);
+            bool? isSubSite = web.ParentWeb.ServerObjectIsNull;
 
-            web.EnsureProperty(w => w.Id);
-            rootWeb.EnsureProperty(w => w.Id);
-
-            if (rootWeb.Id != web.Id)
+            if (isSubSite == true)
             {
-                return true;
+                return false;
             }
             else
             {
-                return false;
+                return true;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PnP Core Component #
-This is the Community Source Code location for PnP Core component. This is a "sub" repository for the PnP repository at [https://github.com/OfficeDev/PnP](https://github.com/OfficeDev/PnP) which will contain PnP core component and related resources. See details around the PnP Core Component from the project [readme file](Core/README.md). 
+This is the Community Source Code location for PnP Core component. This is a "sub" repository for the PnP repository at [https://github.com/OfficeDev/PnP](https://github.com/OfficeDev/PnP) which will contain PnP core component and related resources. See details around the PnP Core Component from the project [readme file](Core/README.md).
 
 ![Office 365 Developer Patterns and Practices](https://camo.githubusercontent.com/a732087ed949b0f2f84f5f02b8c79f1a9dd96f65/687474703a2f2f692e696d6775722e636f6d2f6c3031686876452e706e67)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | No
| New sample?      | No
| Related issues?  | No

#### What's in this Pull Request?

Fix for IsSubSite, previously when using the -admin context, and then opening another site collection, the new site collection would be compared with the -admin root web id when checking to see if it's a sub site, and always returning true. 

Reproduce: 
string tenantName = "mytenant";

using (ClientContext ctx = new ClientContext($"https://{tenantName}-admin.sharepoint.com"))
{
  ctx.Credentials = credentials;
  var tenant = new Tenant(ctx);
  Site site = tenant.GetSiteByUrl($"https://{tenantName}.sharepoint.com");
  Console.WriteLine(site.RootWeb.IsSubSite());
}
