### PR TITLE
TaxonomyField tokenization fix

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -374,6 +374,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             //}
                             //}
                         }
+                        
                         // Check if the field is of type TaxonomyField
                         if (field.TypeAsString.StartsWith("TaxonomyField"))
                         {
@@ -382,30 +383,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             web.Context.ExecuteQueryRetry();
                             taxTextFieldsToMoveUp.Add(taxField.TextField);
 
-                            // Replace Taxonomy field references to SspId, TermSetId with tokens
-                            TaxonomySession session = TaxonomySession.GetTaxonomySession(web.Context);
-                            TermStore store = session.GetDefaultSiteCollectionTermStore();
-
-                            var sspIdElement = element.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'SspId']/Value");
-                            if (sspIdElement != null)
-                            {
-                                sspIdElement.Value = "{sitecollectiontermstoreid}";
-                            }
-                            var termSetIdElement = element.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'TermSetId']/Value");
-                            if (termSetIdElement != null)
-                            {
-                                Guid termSetId = Guid.Parse(termSetIdElement.Value);
-                                if (termSetId != Guid.Empty)
-                                {
-                                    Microsoft.SharePoint.Client.Taxonomy.TermSet termSet = store.GetTermSet(termSetId);
-                                    if (!termSet.ServerObjectIsNull())
-                                    {
-                                        termSet.EnsureProperties(ts => ts.Name, ts => ts.Group);
-                                        termSetIdElement.Value = String.Format("{{termsetid:{0}:{1}}}", termSet.Group.Name, termSet.Name); // TODO
-                                    }
-                                }
-                            }
+                            fieldXml = TokenizeTaxonomyField(web, element);
                         }
+
                         // Check if we have version attribute. Remove if exists 
                         if (element.Attribute("Version") != null)
                         {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1493,6 +1493,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     if (field.TypeAsString.StartsWith("TaxonomyField"))
                     {
+                        schemaXml = TokenizeTaxonomyField(web, fieldElement);
+
                         // find the corresponding taxonomy container text field and include it too
                         var taxField = (TaxonomyField)field;
                         taxField.EnsureProperties(f => f.TextField, f => f.Id);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues? | [#572](https://github.com/OfficeDev/PnP-Sites-Core/issues/572)

#### What's in this Pull Request?

This PR fixes three issues.

1. The termsetid token wasn't set in the field schemaxml because an ExecuteQuery was missing after store.GetTermSet()
2. Only site columns were tokenized. Now also list column taxanomy fields are tokenized.
3. If the TermGroup is a Site Collection Term Group, the group name was inserted in the TermSetId token, and caused the IsFieldXmlValid to fail when provisioning. This is changed to insert the "{sitecollectiontermgroupname}" token.