### PR TITLE
Sitegroups

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -59,23 +59,27 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var allGroups = web.Context.LoadQuery(web.SiteGroups.Include(gr => gr.LoginName));
                     web.Context.ExecuteQueryRetry();
 
-                    if (!web.GroupExists(siteGroup.Title))
+                    string parsedGroupTitle = parser.ParseString(siteGroup.Title);
+                    string parsedGroupOwner = parser.ParseString(siteGroup.Owner);
+                    string parsedGroupDescription = parser.ParseString(siteGroup.Description);
+
+                    if (!web.GroupExists(parsedGroupTitle))
                     {
-                        scope.LogDebug("Creating group {0}", siteGroup.Title);
+                        scope.LogDebug("Creating group {0}", parsedGroupTitle);
                         group = web.AddGroup(
-                            parser.ParseString(siteGroup.Title),
-                            parser.ParseString(siteGroup.Description),
-                            parser.ParseString(siteGroup.Title) == parser.ParseString(siteGroup.Owner));
+                            parsedGroupTitle,
+                            parsedGroupDescription,
+                            parsedGroupTitle == parsedGroupOwner);
                         group.AllowMembersEditMembership = siteGroup.AllowMembersEditMembership;
                         group.AllowRequestToJoinLeave = siteGroup.AllowRequestToJoinLeave;
                         group.AutoAcceptRequestToJoinLeave = siteGroup.AutoAcceptRequestToJoinLeave;
 
-                        if (parser.ParseString(siteGroup.Title) != parser.ParseString(siteGroup.Owner))
+                        if (parsedGroupTitle != parsedGroupOwner)
                         {
-                            Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parser.ParseString(siteGroup.Owner));
+                            Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parsedGroupOwner);
                             if (ownerPrincipal == null)
                             {
-                                ownerPrincipal = web.EnsureUser(parser.ParseString(siteGroup.Owner));
+                                ownerPrincipal = web.EnsureUser(parsedGroupOwner);
                             }
                             group.Owner = ownerPrincipal;
 
@@ -85,7 +89,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                     else
                     {
-                        group = web.SiteGroups.GetByName(parser.ParseString(siteGroup.Title));
+                        group = web.SiteGroups.GetByName(parsedGroupTitle);
                         web.Context.Load(group,
                             g => g.Title,
                             g => g.Description,
@@ -95,9 +99,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             g => g.Owner.LoginName);
                         web.Context.ExecuteQueryRetry();
                         var isDirty = false;
-                        if (!String.IsNullOrEmpty(group.Description) && group.Description != parser.ParseString(siteGroup.Description))
+                        if (!String.IsNullOrEmpty(group.Description) && group.Description != parsedGroupDescription)
                         {
-                            group.Description = parser.ParseString(siteGroup.Description);
+                            group.Description = parsedGroupDescription;
                             isDirty = true;
                         }
                         if (group.AllowMembersEditMembership != siteGroup.AllowMembersEditMembership)
@@ -115,14 +119,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             group.AutoAcceptRequestToJoinLeave = siteGroup.AutoAcceptRequestToJoinLeave;
                             isDirty = true;
                         }
-                        if (group.Owner.LoginName != parser.ParseString(siteGroup.Owner))
+                        if (group.Owner.LoginName != parsedGroupOwner)
                         {
-                            if (parser.ParseString(siteGroup.Title) != parser.ParseString(siteGroup.Owner))
+                            if (parsedGroupTitle != parsedGroupOwner)
                             {
-                                Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parser.ParseString(siteGroup.Owner));
+                                Principal ownerPrincipal = allGroups.FirstOrDefault(gr => gr.LoginName == parsedGroupOwner);
                                 if (ownerPrincipal == null)
                                 {
-                                    ownerPrincipal = web.EnsureUser(parser.ParseString(siteGroup.Owner));
+                                    ownerPrincipal = web.EnsureUser(parsedGroupOwner);
                                 }
                                 group.Owner = ownerPrincipal;
                             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | have not checked if there are related issues

#### What's in this Pull Request?

fix: check if a group exists with a unparsed title is inconsistent with adding the group with a parsed title. This can result in an exception when a group including {sitename} is used.

changed: 'excessive' parsing to parsing once

fix: if the principal is a sharepoint group, the name of the principal should also replace the site title as is done for sitegroups. If not an inconsistency can occur causing an exception when provisioning the template, the group/principal might not exist.

fix: don't add a role assignment for a principal if the principal is a sharepoint group when sharepoint groups are not included. Provisioning will fail if the group/principal does not exist, and they will probably not exist (other than the default groups) if the are not in the provisioning template.

changed: only call ReplaceGroupTokens for sharepoint groups, otherwise there is no need for this method. This also prevents issues in rare cases where the loginName includes the site title or one of the default group names.

fix: when a template is generated from a site that has a subsite with unique permissions, when provisioning an exception can occur on a non existing group owner. Also groups not used in the site, should not be included in the template.