### PR TITLE
Localization not set on list site columns

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -127,14 +127,45 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 {
                                     if (!listInfo.SiteList.FieldExistsById(fieldRef.Id))
                                     {
-                                        CreateFieldRef(listInfo, field, fieldRef);
+                                        field = CreateFieldRef(listInfo, field, fieldRef);
                                     }
                                     else
                                     {
-                                        UpdateFieldRef(listInfo.SiteList, field.Id, fieldRef);
+                                        field = UpdateFieldRef(listInfo.SiteList, field.Id, fieldRef);
                                     }
                                 }
 
+#if !ONPREMISES
+                                var siteField = template.SiteFields.FirstOrDefault(f => Guid.Parse(XElement.Parse(f.SchemaXml).Attribute("ID").Value).Equals(field.Id));
+
+                                if (siteField != null && siteField.SchemaXml.ContainsResourceToken())
+                                {
+                                    var isDirty = false;
+                                    var originalFieldElement = XElement.Parse(siteField.SchemaXml);
+                                    var nameAttributeValue = originalFieldElement.Attribute("DisplayName") != null ? originalFieldElement.Attribute("DisplayName").Value : "";
+                                    if (nameAttributeValue.ContainsResourceToken())
+                                    {
+                                        if (field.TitleResource.SetUserResourceValue(nameAttributeValue, parser))
+                                        {
+                                            isDirty = true;
+                                        }
+                                    }
+                                    var descriptionAttributeValue = originalFieldElement.Attribute("Description") != null ? originalFieldElement.Attribute("Description").Value : "";
+                                    if (descriptionAttributeValue.ContainsResourceToken())
+                                    {
+                                        if (field.DescriptionResource.SetUserResourceValue(descriptionAttributeValue, parser))
+                                        {
+                                            isDirty = true;
+                                        }
+                                    }
+
+                                    if (isDirty)
+                                    {
+                                        field.Update();
+                                        field.Context.ExecuteQuery();
+                                    }
+                                }
+#endif
                             }
                             listInfo.SiteList.Update();
                             web.Context.ExecuteQueryRetry();
@@ -449,12 +480,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        private static void UpdateFieldRef(List siteList, Guid fieldId, FieldRef fieldRef)
+        private static Field UpdateFieldRef(List siteList, Guid fieldId, FieldRef fieldRef)
         {
             // find the field in the list
             var listField = siteList.Fields.GetById(fieldId);
 
-            siteList.Context.Load(listField, f => f.Title, f => f.Hidden, f => f.Required);
+            siteList.Context.Load(listField, f => f.Id, f => f.Title, f => f.Hidden, f => f.Required);
             siteList.Context.ExecuteQueryRetry();
 
             var isDirty = false;
@@ -487,9 +518,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 listField.UpdateAndPushChanges(true);
                 siteList.Context.ExecuteQueryRetry();
             }
+
+            return listField;
         }
 
-        private static void CreateFieldRef(ListInfo listInfo, Field field, FieldRef fieldRef)
+        private static Field CreateFieldRef(ListInfo listInfo, Field field, FieldRef fieldRef)
         {
             field.EnsureProperty(f => f.SchemaXmlWithResourceTokens);
             XElement element = XElement.Parse(field.SchemaXmlWithResourceTokens);
@@ -500,7 +533,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             var createdField = listInfo.SiteList.Fields.Add(field);
 
-            createdField.Context.Load(createdField, cf => cf.Title, cf => cf.Hidden, cf => cf.Required);
+            createdField.Context.Load(createdField, cf => cf.Id, cf => cf.Title, cf => cf.Hidden, cf => cf.Required);
             createdField.Context.ExecuteQueryRetry();
 
             var isDirty = false;
@@ -524,6 +557,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 createdField.Update();
                 createdField.Context.ExecuteQueryRetry();
             }
+
+            return createdField;
         }
 
         private static void CreateField(XElement fieldElement, ListInfo listInfo, TokenParser parser, string originalFieldXml, ClientRuntimeContext context, PnPMonitoredScope scope)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | N/A

#### What's in this Pull Request?

When site columns are added to a list, the TitleResource and DescriptionResource isn't inherited from the site column. These explicit need to be set after the field is added.

This fix checks if the site column in the template contains a resource token and then sets the TitleResource or DescriptionResource.

One could argue that using resource token in the FieldRef element is a better solution, however the schema only allows DisplayName in the FieldRef element and not Description.