### PR TITLE
Removed cyphering capability from OpenXML

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXMLConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXMLConnector.cs
@@ -30,12 +30,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <param name="persistenceConnector">The FileConnector object that will be used for physical persistence of the file</param>
         /// <param name="author">The Author of the .PNP package file, if any. Optional</param>
         /// <param name="signingCertificate">The X.509 certificate to use for digital signature of the template, optional</param>
-        /// <param name="cypheringCertificate">The X.509 certificate to use for encryption of the template, optional</param>
         public OpenXMLConnector(string packageFileName,
             FileConnectorBase persistenceConnector, 
             String author = null,
-            X509Certificate2 signingCertificate = null,
-            X509Certificate2 cypheringCertificate = null)
+            X509Certificate2 signingCertificate = null)
             : base()
         {
             if (String.IsNullOrEmpty(packageFileName))

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Json/JsonOpenXMLTemplateProvider.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Json/JsonOpenXMLTemplateProvider.cs
@@ -13,10 +13,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Json
         public JsonOpenXMLTemplateProvider(string packageFileName,
             FileConnectorBase persistenceConnector,
             String author = null,
-            X509Certificate2 signingCertificate = null,
-            X509Certificate2 cypheringCertificate = null) :
+            X509Certificate2 signingCertificate = null) :
             base(new OpenXMLConnector(packageFileName, persistenceConnector,
-                author, signingCertificate, cypheringCertificate))
+                author, signingCertificate))
         {
         }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLOpenXMLTemplateProvider.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLOpenXMLTemplateProvider.cs
@@ -14,10 +14,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
         public XMLOpenXMLTemplateProvider(string packageFileName,
             FileConnectorBase persistenceConnector,
             String author = null,
-            X509Certificate2 signingCertificate = null,
-            X509Certificate2 cypheringCertificate = null) :
+            X509Certificate2 signingCertificate = null) :
             base(new OpenXMLConnector(packageFileName, persistenceConnector,
-                author, signingCertificate, cypheringCertificate))
+                author, signingCertificate))
         {
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | nothing

#### What's in this Pull Request?

Removed the encyphering arguments, because we will not provide encryption in the OpenXML connector.