### PR TITLE
Fixed not supported linq error when extracting terms sets running OnPremSP2013

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -362,7 +362,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             Description = termGroup.Description
                         };
 
-                        foreach (var termSet in termGroup.TermSets.Where(ts => ts.Id != orphanedTermsTermSetId))
+                        var nonOrphanTermSets = new List<TermSet>();
+                        foreach (var termSet in termGroup.TermSets)
+                        {
+                            if (termSet.Id != orphanedTermsTermSetId)
+                            {
+                                nonOrphanTermSets.Add(termSet);
+                            }
+                        }
+
+                        foreach (var termSet in nonOrphanTermSets)
                         {
                             var modelTermSet = new Model.TermSet();
                             modelTermSet.Name = termSet.Name;

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -362,17 +362,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             Description = termGroup.Description
                         };
 
-                        var nonOrphanTermSets = new List<TermSet>();
                         foreach (var termSet in termGroup.TermSets)
                         {
-                            if (termSet.Id != orphanedTermsTermSetId)
-                            {
-                                nonOrphanTermSets.Add(termSet);
-                            }
-                        }
+                            // Do not include the orphan term set
+                            if (termSet.Id == orphanedTermsTermSetId) continue;
 
-                        foreach (var termSet in nonOrphanTermSets)
-                        {
+                            // Extract all other term sets
                             var modelTermSet = new Model.TermSet();
                             modelTermSet.Name = termSet.Name;
                             if (!isSiteCollectionTermGroup)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Valid Scenario: On premises SharePoint 2013
Issue: Framework.Provisioning.ObjectHandlers.ObjectTermGroups:ExtractObjects() previously threw a method not supported exception when attempting to limit term sets to only those which where not the orphan term set. This fix replaces the inline linq query. 