### PR TITLE
Fixed issue when provisioning template has files for the web root fol…

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/FileFolderExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/FileFolderExtensionsTests.cs
@@ -256,6 +256,60 @@ namespace OfficeDevPnP.Core.Tests.AppModelExtensions
             clientContext.ExecuteQueryRetry();
             Assert.AreEqual(testFolder.ServerRelativeUrl, String.Format("{0}/{1}/{2}",clientContext.Web.ServerRelativeUrl, DocumentLibraryName, folderName));
         }
+
+        [TestMethod]
+        public void EnsureWebRootFolderPathTest()
+        {
+            string folderName = string.Empty;
+
+            Folder rootFolder = clientContext.Web.EnsureFolderPath(folderName);
+
+            Assert.AreEqual(clientContext.Web.ServerRelativeUrl.TrimEnd('/'), rootFolder.ServerRelativeUrl.TrimEnd('/'));
+        }
+
+        [TestMethod]
+        public void EnsureFolderPathTest()
+        {
+            string folderName = "test_path";
+
+            var testFolder = clientContext.Web.EnsureFolderPath(folderName);
+
+            Assert.AreEqual(string.Format("{0}/{1}", clientContext.Web.ServerRelativeUrl.TrimEnd('/'), folderName), testFolder.ServerRelativeUrl.TrimEnd('/'));
+        }
+
+        [TestMethod]
+        public void EnsureLibraryRootFolderPathTest()
+        {
+            string folderName = DocumentLibraryName;
+
+            Folder libraryRootFolder = clientContext.Web.EnsureFolderPath(folderName);
+
+            Assert.AreEqual(documentLibrary.RootFolder.ServerRelativeUrl.TrimEnd('/'), libraryRootFolder.ServerRelativeUrl.TrimEnd('/'));
+        }
+
+        [TestMethod]
+        public void EnsureLibraryFolderPathTest()
+        {
+            string folderName = "test_path";
+            string folderPath = string.Format("{0}/{1}", DocumentLibraryName, folderName);
+
+            Folder libraryFolder = clientContext.Web.EnsureFolderPath(folderPath);
+
+            clientContext.Load(documentLibrary, d => d.RootFolder, d => d.RootFolder.Folders);
+            clientContext.ExecuteQueryRetry();
+            ensureLibraryFolderTest = null;
+            foreach (Folder existingFolder in documentLibrary.RootFolder.Folders)
+            {
+                if (string.Equals(existingFolder.Name, folderName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    ensureLibraryFolderTest = existingFolder;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(ensureLibraryFolderTest);
+            Assert.AreEqual(ensureLibraryFolderTest.ServerRelativeUrl.TrimEnd('/'), libraryFolder.ServerRelativeUrl.TrimEnd('/'));
+        }
         #endregion
 
     }

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -367,10 +367,12 @@ namespace Microsoft.SharePoint.Client
         public static Folder EnsureFolderPath(this Web web, string webRelativeUrl)
         {
             if (webRelativeUrl == null) { throw new ArgumentNullException("webRelativeUrl"); }
-            if (string.IsNullOrWhiteSpace(webRelativeUrl)) { throw new ArgumentException(CoreResources.FileFolderExtensions_EnsureFolderPath_Folder_URL_is_required_, "webRelativeUrl"); }
+
+            //Web root folder should be returned if webRelativeUrl is empty
+            if (webRelativeUrl.Length != 0 && string.IsNullOrWhiteSpace(webRelativeUrl)) { throw new ArgumentException(CoreResources.FileFolderExtensions_EnsureFolderPath_Folder_URL_is_required_, "webRelativeUrl"); }
 
             // Check if folder exists
-            if (!web.IsObjectPropertyInstantiated("ServerRelativeUrl"))
+            if (!web.IsPropertyAvailable("ServerRelativeUrl"))
             {
                 web.Context.Load(web, w => w.ServerRelativeUrl);
                 web.Context.ExecuteQueryRetry();
@@ -379,7 +381,7 @@ namespace Microsoft.SharePoint.Client
 
             // Check if folder is inside a list
             var listCollection = web.Lists;
-            web.Context.Load(listCollection, lc => lc.Include(l => l.RootFolder.ServerRelativeUrl));
+            web.Context.Load(listCollection, lc => lc.Include(l => l.RootFolder)); 
             web.Context.ExecuteQueryRetry();
 
             List containingList = null;
@@ -400,7 +402,7 @@ namespace Microsoft.SharePoint.Client
             {
                 locationType = "Web";
                 currentFolder = web.RootFolder;
-                web.Context.Load(currentFolder, f => f.ServerRelativeUrl);
+                web.Context.Load(currentFolder);
                 web.Context.ExecuteQueryRetry();
             }
             else


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

Fixed issue when provisioning template has files for the web root folder.
Modified EnsureFolderPath to allow an empty string for webRelativeUrl so that retrieval of web root folder is supported.
Fixed incorrect check for availability of ServerRelativeUrl in EnsureFolderPath.
Modified EnsureFolderPath to return folder objects instantiated in a consistent manner (all properties populated even if a root folder is returned).
Added tests for EnsureFolderPath method