### PR TITLE
Updated NuGet dependencies to use on-prem versions and not SharePoint…

### DIFF
--- a/Core/SharePointPnPCore2013.2.4.1605.0.nuspec
+++ b/Core/SharePointPnPCore2013.2.4.1605.0.nuspec
@@ -17,7 +17,7 @@
         <dependencies>
             <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
             <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
-            <dependency id="AppForSharePointOnlineWebToolkit" version="3.1.2" />
+            <dependency id="AppForSharePointWebToolkit" version="3.1.2" />
         </dependencies>
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/Core/SharePointPnPCore2016.2.4.1605.0.nuspec
+++ b/Core/SharePointPnPCore2016.2.4.1605.0.nuspec
@@ -17,7 +17,7 @@
         <dependencies>
             <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
             <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
-            <dependency id="AppForSharePointOnlineWebToolkit" version="3.1.2" />
+            <dependency id="AppForSharePointWebToolkit" version="3.1.2" />
         </dependencies>
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System" targetFramework="" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no 

#### What's in this Pull Request?

The SharePointPnPCore2013 and SharePointPnPCore2016 NuGet packages for on-prem reference the AppForSharePointOnlineWebToolkit which is intended for use in SharePoint online add-ins. Changed dependency to AppForSharePointWebToolkit which is intended for on-prem.

Generally it would help a lot to get rid of the AppForSharePointWebToolkit dependency. The PnP project does not really depend on it and if people want to use the SPContext and TokenHelper from the AppForSharePointWebToolkit package they can add the nuget package themself. Please (re-)consider this option. Thanks.