### PR TITLE
BUGFIX - Lists in sub sites with field references are extracted with list fields instead

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1381,9 +1381,14 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
         private ListInstance ExtractFields(Web web, List siteList, List<FieldRef> contentTypeFields, ListInstance list, List<List> lists, ProvisioningTemplateCreationInformation creationInfo, ProvisioningTemplate template)
         {
-            var siteColumns = web.Fields;
-            web.Context.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue));
-            web.Context.ExecuteQueryRetry();
+            var siteContext = web.Context.GetSiteCollectionContext();
+            var rootWeb = siteContext.Site.RootWeb;
+            siteContext.Load(rootWeb);
+            siteContext.ExecuteQueryRetry();
+
+            var siteColumns = rootWeb.Fields;
+            siteContext.Load(siteColumns, scs => scs.Include(sc => sc.Id, sc => sc.DefaultValue));
+            siteContext.ExecuteQueryRetry();
 
             foreach (var field in siteList.Fields.AsEnumerable().Where(field => !field.Hidden))
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Scenario: Extracting lists existing in a sub site with field references to site fields.
Problem: List field references not detected and all fields added as list fields instead.
Fix: Changed ObjectListInstance:ExtractFields() to always load the site fields for comparison from the root spweb in the site collection