### PR TITLE
Add ListExists() based on List's url path

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
@@ -155,6 +155,100 @@ namespace Microsoft.SharePoint.Client.Tests
         }
         #endregion
 
+        #region List Existence tests
+        [TestMethod]
+        public void ListExistsByGuidTest()
+        {
+            var listName = "samplelist_" + DateTime.Now.ToFileTime();
+            var listGuid = Guid.NewGuid();
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+
+                var list = clientContext.Web.CreateList(
+                    ListTemplateType.GenericList,
+                    listName,
+                    false);
+
+
+                clientContext.Load<List>(list, l => l.Id);
+                clientContext.ExecuteQueryRetry();
+
+                Assert.IsNotNull(list);
+                Assert.IsTrue(clientContext.Web.ListExists(list.Id));
+
+                //Delete List
+                list.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ListExistsWithEmtpyTitleParameterTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                clientContext.Web.ListExists(string.Empty);
+            }
+        }
+
+        [TestMethod]
+        public void ListExistsByTitleTest()
+        {
+            var listName = "samplelist_" + DateTime.Now.ToFileTime();
+            var listGuid = Guid.NewGuid();
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+
+                var list = clientContext.Web.CreateList(
+                    ListTemplateType.GenericList,
+                    listName,
+                    false);
+
+                Assert.IsNotNull(list);
+                Assert.IsTrue(clientContext.Web.ListExists(listName));
+
+                //Delete List
+                list.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ListExistsByUrlPathIsNullParamTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                clientContext.Web.ListExists((Uri)null);
+            }
+        }
+
+        [TestMethod]
+        public void ListExistsByUrlPathParamTest()
+        {
+            var listName = "samplelist_" + DateTime.Now.ToFileTime();
+            var siteRelativePath = $"Lists/{listName}";
+
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var list = clientContext.Web.CreateList(
+                    ListTemplateType.GenericList,
+                    listName,
+                    false);
+
+                Assert.IsNotNull(list);
+                Assert.IsTrue(clientContext.Web.ListExists(new Uri(siteRelativePath,UriKind.Relative)));
+
+                //Delete List
+                list.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+            }
+        }
+        #endregion  
+
         #region Get Lists/Library tests
 
         public void GetPagesLibraryTest()

--- a/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -337,12 +337,24 @@ namespace Microsoft.SharePoint.Client
             web.Context.ExecuteQueryRetry();
             List existingList = results.FirstOrDefault();
 
-            if (existingList != null)
+            return results.Any();
+        }
+
+        public static bool ListExists(this Web web, Uri siteRelativeUrlPath)
+        {
+            if (siteRelativeUrlPath == null)
             {
-                return true;
+                throw new ArgumentNullException("siteRelativeUrlPath");
             }
 
-            return false;
+            ListCollection lists = web.Lists;
+            web.Context.Load(web, obj => obj.ServerRelativeUrl);
+            web.Context.ExecuteQueryRetry();
+
+            var listResult = web.GetList(UrlUtility.Combine(web.ServerRelativeUrl, siteRelativeUrlPath.ToString()));
+            web.Context.ExecuteQueryRetry();
+
+            return listResult != null;
         }
 
         /// <summary>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

Added a few ListExists() test cases, and wrote an additional overload that determines if the List exists based on url path.

This is handy to have as when using CreateList method overload you can hard-code url path and at times when lists are renamed, it's hard to determine by title if list already exists.