### PR TITLE
Fix: FieldRefs containing replacement tokens are ordered wrong

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectContentTypeTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectContentTypeTests.cs
@@ -10,6 +10,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using ContentType = OfficeDevPnP.Core.Framework.Provisioning.Model.ContentType;
+using Field = OfficeDevPnP.Core.Framework.Provisioning.Model.Field;
 
 namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
 {
@@ -24,11 +25,14 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
             using (var ctx = TestCommon.CreateClientContext())
             {
                 var ct = ctx.Web.GetContentTypeByName("Test Content Type");
+                //var field = ctx.Web.Fields.GetByInternalNameOrTitle("TestField");
                 if (ct != null)
                 {
                     ct.DeleteObject();
                     ctx.ExecuteQueryRetry();
                 }
+                ctx.Web.RemoveFieldByInternalName("PnPTestField");
+
             }
         }
 
@@ -63,6 +67,54 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var ct = ctx.Web.GetContentTypeByName("Test Content Type");
 
                 Assert.IsNotNull(ct);
+
+            }
+        }
+
+        [TestMethod]
+        public void FieldUsingTokensAreCorrectlyOrdered()
+        {
+            var template = new ProvisioningTemplate();
+
+            template.Parameters.Add("TestFieldPrefix","PnP");
+            
+
+            var contentType = new ContentType
+            {
+                Id = "0x010100503B9E20E5455344BFAC2292DC6FE805",
+                Name = "Test Content Type",
+                Group = "PnP",
+                Description = "Test Description",
+                Overwrite = true,
+                Hidden = false
+            };
+
+            var nonOobField = new Field
+            {
+                SchemaXml = "<Field ID=\"{dd6b7dae-1281-458d-a66c-01b0c7b7930b}\" Name=\"{parameter:TestFieldPrefix}TestField\" DisplayName=\"TestField\" Type=\"Note\" Group=\"PnP\" Description=\"\" />"
+            };
+            template.SiteFields.Add(nonOobField);
+
+            contentType.FieldRefs.Add(new FieldRef("{parameter:TestFieldPrefix}TestField")
+            {
+                Id= new Guid("{dd6b7dae-1281-458d-a66c-01b0c7b7930b}")
+            });
+
+            contentType.FieldRefs.Add(new FieldRef("AssignedTo")
+            {
+                Id = BuiltInFieldId.AssignedTo
+            });
+            template.ContentTypes.Add(contentType);
+
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                TokenParser parser = new TokenParser(ctx.Web, template);
+                new ObjectField().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
+                new ObjectContentType().ProvisionObjects(ctx.Web, template, parser, new ProvisioningTemplateApplyingInformation());
+                var ct = ctx.Web.GetContentTypeByName("Test Content Type");
+                ct.EnsureProperty(x => x.FieldLinks);
+                Assert.AreEqual(ct.FieldLinks[0].Id, template.ContentTypes.First().FieldRefs[0].Id);
+                Assert.AreEqual(ct.FieldLinks[1].Id, template.ContentTypes.First().FieldRefs[1].Id);
 
             }
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -257,7 +257,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             //template. The order can be different if the new Content Type inherits from another Content Type.
             //In this case the new Content Type has all field of the original Content Type and missing fields 
             //will be added at the end. To fix this issue we ordering the fields once more.
-            createdCT.FieldLinks.Reorder(templateContentType.FieldRefs.Select(fld => fld.Name).ToArray());
+
+            createdCT.FieldLinks.Reorder(templateContentType.FieldRefs.Select(fld => parser.ParseString(fld.Name)).ToArray());
 
             createdCT.ReadOnly = templateContentType.ReadOnly;
             createdCT.Hidden = templateContentType.Hidden;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Fixing issue where we have fields defined with internal names containing tokens and re-ordering of these. The bug manifested itself through OOB fields getting sorted before our custom fields for no apparent reason. The unittest reflects this scenario.

example 
This field 
`<Field ID="{dd6b7dae-1281-458d-a66c-01b0c7b7930b}" Name="{parameter:TestFieldPrefix}TestField" DisplayName="TestField" Type="Note" Group="PnP" Description="" />
`

Would end up as the last field when referenced like this

```
<pnp:ContentType ID="0x010100503B9E20E5455344BFAC2292DC6FE805" Name="Test Content Type" Description="" Group="PnP}">
    <pnp:FieldRefs>
        <pnp:FieldRef ID="dd6b7dae-1281-458d-a66c-01b0c7b7930b" Name="{parameter:TestFieldPrefix}TestField" />
        <pnp:FieldRef ID="53101f38-dd2e-458c-b245-0c236cc13d1a" Name="AssignedTo" />
    </pnp:FieldRefs>
</pnp:ContentType>
```

A work around could of course be to not use tokens when adding fieldrefs, but that defeats the purpose of supporting tokens in the first place