### PR TITLE
Make Remote Timer Job Work OnPrem

### DIFF
--- a/Core/OfficeDevPnP.Core/AuthenticationManager.cs
+++ b/Core/OfficeDevPnP.Core/AuthenticationManager.cs
@@ -94,7 +94,14 @@ namespace OfficeDevPnP.Core
         /// <returns>ClientContext to be used by CSOM code</returns>
         public ClientContext GetAppOnlyAuthenticatedContext(string siteUrl, string realm, string appId, string appSecret, string acsHostUrl = "accesscontrol.windows.net", string globalEndPointPrefix = "accounts")
         {
+
+#if ONPREMISES
+            //As in Kirk Evans blog the app only context is created this way for S2S
+            //https://blogs.msdn.microsoft.com/kaevans/2013/02/23/sharepoint-2013-app-only-policy-made-easy/
+            appOnlyAccessToken = TokenHelper.GetS2SAccessTokenWithWindowsIdentity(new Uri(siteUrl), null);             
+#else
             EnsureToken(siteUrl, realm, appId, appSecret, acsHostUrl, globalEndPointPrefix);
+#endif
             ClientContext clientContext = Utilities.TokenHelper.GetClientContextWithAccessToken(siteUrl, appOnlyAccessToken);
             return clientContext;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

The fix adjusts code for Remote Timer Jobs. Using AppOnlyContext in the Remote Timer Job framework OnPrem resulted in the 400 Bad Request Error: 

```
The remote server returned an error: (400) Bad Request. - {"error":"invalid_request","error_description":"AADSTS90002: 
No service namespace named '95650b5e-bcbc-4ddc-8170-b31e1f4b4f05' was found in the data store.
Trace ID: c3484490-566a-4892-998d-2819d393d4ab
Correlation ID: 84948f76-8c0f-4bc9-824b-7b6b54d03582\r\n
```

The reason it fails is the call to accounts.windows.net which (AFAIK) should not be done for S2S:
![image](https://cloud.githubusercontent.com/assets/470105/16266998/d9a2d0ec-3887-11e6-90a5-2c657e51fbad.png)

So using [Kirk Evans Blog Post](https://blogs.msdn.microsoft.com/kaevans/2013/02/23/sharepoint-2013-app-only-policy-made-easy/) we changed OfficeDevPnP.Core.AuthenticationManager.GetAppOnlyAuthenticatedContext from this
```
EnsureToken(siteUrl, realm, appId, appSecret, acsHostUrl, globalEndPointPrefix);
ClientContext clientContext = Utilities.TokenHelper.GetClientContextWithAccessToken(siteUrl, appOnlyAccessToken);
return clientContext;
```
to this where a simpler solution is used for OnPremises environment:
```OfficeDevPnP.Core.AuthenticationManager
#if ONPREMISES
 //As in Kirk Evans blog the app only context is created this way for S2S
 //https://blogs.msdn.microsoft.com/kaevans/2013/02/23/sharepoint-2013-app-only-policy-made-easy/
appOnlyAccessToken = TokenHelper.GetS2SAccessTokenWithWindowsIdentity(new Uri(siteUrl), null);             
#else
EnsureToken(siteUrl, realm, appId, appSecret, acsHostUrl, globalEndPointPrefix);
#endif
ClientContext clientContext = Utilities.TokenHelper.GetClientContextWithAccessToken(siteUrl, appOnlyAccessToken);
return clientContext;
```

