### PR TITLE
Added URL decoding in the Tokenize method. If an object has been crea…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -195,6 +195,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
             else
             { 
+                // Decode URL
+                url = Uri.UnescapeDataString(url);
                 // Try with theme catalog
                 if (url.IndexOf("/_catalogs/theme", StringComparison.InvariantCultureIgnoreCase) > -1)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes

Added a small fix to the Tokenize method. If a URL contains spaces, SharePoint sometimes returns them as encoded strings with "%20" instead of real spaces. This results in a URL without a token. With this fix, the URL will get decoded first.