### PR TITLE
Master page URL token fix when provisioning template to a sub-site.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/MasterPageCatalogToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/MasterPageCatalogToken.cs
@@ -13,7 +13,18 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
         {
             if (this.CacheValue == null)
             {
-                var catalog = Web.GetCatalog((int) ListTemplateType.MasterPageCatalog);
+                List catalog;
+                // Check if the current web is a sub-site
+                if (Web.IsSubSite())
+                {
+                    // Master page URL needs to be retrieved from the rootweb
+                    var rootWeb = (Web.Context as ClientContext).Site.RootWeb;
+                    catalog = rootWeb.GetCatalog((int)ListTemplateType.MasterPageCatalog);
+                }
+                else
+                {
+                    catalog = Web.GetCatalog((int)ListTemplateType.MasterPageCatalog);
+                }
                 Web.Context.Load(catalog, c => c.RootFolder.ServerRelativeUrl);
                 Web.Context.ExecuteQueryRetry();
                 CacheValue = catalog.RootFolder.ServerRelativeUrl;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

This fixes an issue with replacing the {masterpagecatalog} with the correct master page catalog URL. 

At the moment the token gets replaced with the master page catalog URL of the web you are provisioning the template at. If the web is a sub-site. This returns the path to the master page gallery URL of that web and causes a file not found issue (because the reference is set to /site/sub-site/_catalogs/masterpage/custom.master).

With this fix, it will be retrieved from the rootweb if the current web is a sub-site. The returned URL is: _catalogs/masterpage.
