### PR TITLE
Fix for edge case with backward compatibility issue in folders handling.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXML/PnPPackageHelper.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/OpenXML/PnPPackageHelper.cs
@@ -72,7 +72,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors.OpenXML
                     new PnPFileInfo
                     {
                         InternalName = file.Key,
-                        OriginalName = package.FilesMap.Map[file.Key].Replace(file.Value.Folder + '/', ""),
+                        OriginalName = String.IsNullOrEmpty(file.Value.Folder) ?
+                            package.FilesMap.Map[file.Key] :
+                            package.FilesMap.Map[file.Key].Replace(file.Value.Folder + '/', ""),
                         Folder = file.Value.Folder,
                         Content = file.Value.Content,
                     });


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no

#### What's in this Pull Request?

Fixes an issue related to an edge case that lead to a backward compatibility issue while handling .PNP files created with the old format (with folders structure) opened and then saved again with the new format (without folders structure).