### PR TITLE
Added capability to do pre/post-extensions during template load/save

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/Extensibility/SecureXml.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/Extensibility/SecureXml.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace OfficeDevPnP.Core.Tests.Framework.Providers.Extensibility
+{
+    public class SecureXml
+    {
+        private static Rijndael rKey = new RijndaelManaged();
+
+        static SecureXml()
+        {
+            rKey.GenerateKey();
+            rKey.GenerateIV();
+        }
+
+        private SecureXml() { }
+
+        public static void SignXmlDocument(Stream sourceXmlFile,
+            Stream destinationXmlFile, X509Certificate2 certificate)
+        {
+            // Carico il documento XML
+            XmlDocument doc = new XmlDocument();
+            doc.Load(sourceXmlFile);
+
+            // Preparo un DOMDocument che conterrà il risultato
+            XmlDocument outputDocument = new XmlDocument();
+
+            // Recupero un riferimento all'intero contenuto del documento XML
+            XmlNodeList elementsToSign = doc.SelectNodes(String.Format("/{0}", doc.DocumentElement.Name));
+
+            // Costruisco la firma
+            SignedXml signedXml = new SignedXml();
+            System.Security.Cryptography.Xml.DataObject dataSignature =
+                new System.Security.Cryptography.Xml.DataObject();
+            dataSignature.Data = elementsToSign;
+            dataSignature.Id = doc.DocumentElement.Name;
+            signedXml.AddObject(dataSignature);
+            Reference reference = new Reference();
+            reference.Uri = String.Format("#{0}", dataSignature.Id);
+            signedXml.AddReference(reference);
+
+            if ((certificate != null) && (certificate.HasPrivateKey))
+            {
+                signedXml.SigningKey = certificate.PrivateKey;
+
+                KeyInfo keyInfo = new KeyInfo();
+                keyInfo.AddClause(new KeyInfoX509Data(certificate));
+                signedXml.KeyInfo = keyInfo;
+                signedXml.ComputeSignature();
+
+                // Aggiungo la firma al nuovo documento di output
+                outputDocument.AppendChild(
+                    outputDocument.ImportNode(signedXml.GetXml(), true));
+
+                outputDocument.Save(destinationXmlFile);
+            }
+        }
+
+        public static Boolean CheckSignedXmlDocument(Stream sourceXmlFile)
+        {
+            // Carico il documento XML
+            XmlDocument doc = new XmlDocument();
+            doc.Load(sourceXmlFile);
+
+            // Verifico la firma
+            SignedXml sigs = new SignedXml(doc);
+            XmlNodeList sigElems = doc.GetElementsByTagName("Signature");
+            sigs.LoadXml((XmlElement)sigElems[0]);
+            return (sigs.CheckSignature());
+        }
+
+        public static void EncryptXmlDocument(Stream sourceXmlFile,
+            Stream destinationXmlFile,
+            String xpathNodeToEncrypt,
+            Dictionary<String, String> namespaces,
+            X509Certificate2 certificate)
+        {
+            // Carico il documento XML
+            XmlDocument doc = new XmlDocument();
+            doc.Load(sourceXmlFile);
+
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(doc.NameTable);
+            if (namespaces != null)
+            {
+                foreach (var prefix in namespaces.Keys)
+                {
+                    namespaceManager.AddNamespace(prefix, namespaces[prefix]);
+                }
+            }
+
+            // Estraggo l'elemento da cifrare
+            XmlElement elementToEncrypt = doc.SelectSingleNode(xpathNodeToEncrypt, namespaceManager) as XmlElement;
+
+            // Cifro il nodo di tipo elemento
+            EncryptedXml enc = new EncryptedXml(doc);
+            EncryptedData ed = enc.Encrypt(elementToEncrypt, certificate);
+
+            // Lo sostituisco all'elemento originale
+            EncryptedXml.ReplaceElement(elementToEncrypt,
+                ed, false);
+
+            // Salvo il risultato
+            doc.Save(destinationXmlFile);
+        }
+
+        public static void DecryptXmlDocument(
+            Stream sourceXmlFile,
+            Stream destinationXmlFile,
+            X509Certificate2 certificate)
+        {
+            // Apro il documento
+            XmlDocument doc = new XmlDocument();
+            doc.Load(sourceXmlFile);
+
+            // Decifro il nodo di tipo elemento
+            EncryptedXml enc = new EncryptedXml(doc);
+            enc.DecryptDocument();
+
+            // Salvo il risultato
+            doc.Save(destinationXmlFile);
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Providers/Extensibility/XMLEncryptionTemplateProviderExtension.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Providers/Extensibility/XMLEncryptionTemplateProviderExtension.cs
@@ -1,0 +1,88 @@
+﻿using OfficeDevPnP.Core.Framework.Provisioning.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
+
+namespace OfficeDevPnP.Core.Tests.Framework.Providers.Extensibility
+{
+    public class XMLEncryptionTemplateProviderExtension : ITemplateProviderExtension
+    {
+        public bool SupportsGetTemplatePostProcessing
+        {
+            get
+            {
+                return (false);
+            }
+        }
+
+        public bool SupportsGetTemplatePreProcessing
+        {
+            get
+            {
+                return (true);
+            }
+        }
+
+        public bool SupportsSaveTemplatePostProcessing
+        {
+            get
+            {
+                return (true);
+            }
+        }
+
+        public bool SupportsSaveTemplatePreProcessing
+        {
+            get
+            {
+                return (false);
+            }
+        }
+
+        private X509Certificate2 _certificate;
+
+        public void Initialize(object settings)
+        {
+            _certificate = settings as X509Certificate2;
+        }
+
+        public ProvisioningTemplate PostProcessGetTemplate(ProvisioningTemplate template)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Stream PostProcessSaveTemplate(Stream stream)
+        {
+            MemoryStream result = new MemoryStream();
+
+            var namespaces = new Dictionary<string, string>();
+            namespaces.Add("pnp", XMLConstants.PROVISIONING_SCHEMA_NAMESPACE_2016_05);
+
+            SecureXml.EncryptXmlDocument(stream, result, "/pnp:Provisioning", namespaces, this._certificate);
+            result.Position = 0;
+
+            return (result);
+        }
+
+        public Stream PreProcessGetTemplate(Stream stream)
+        {
+            MemoryStream result = new MemoryStream();
+
+            SecureXml.DecryptXmlDocument(stream, result, this._certificate);
+            result.Position = 0;
+
+            return (result);
+        }
+
+        public ProvisioningTemplate PreProcessSaveTemplate(ProvisioningTemplate template)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
+++ b/Core/OfficeDevPnP.Core.Tests/OfficeDevPnP.Core.Tests.csproj
@@ -281,6 +281,7 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Selectors" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -368,6 +369,8 @@
     <Compile Include="Framework\ObjectHandlers\ObjectContentTypeTests.cs" />
     <Compile Include="Framework\ObjectHandlers\TokenParserTests.cs" />
     <Compile Include="Framework\Providers\BaseTemplateTests.cs" />
+    <Compile Include="Framework\Providers\Extensibility\SecureXml.cs" />
+    <Compile Include="Framework\Providers\Extensibility\XMLEncryptionTemplateProviderExtension.cs" />
     <Compile Include="Framework\Providers\XMLProvidersTests.cs" />
     <Compile Include="Framework\ProvisioningTemplates\DomainModelTests.cs" />
     <Compile Include="Utilities\JsonUtilityTests.cs" />
@@ -460,8 +463,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-NOT-Valid-XInclude-01.xml" />
-    <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-Sample-01.xml" />
-    <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-Sample-02.xml" />
+    <Content Include="Resources\Templates\ProvisioningTemplate-2016-05-Sample-01.xml" />
+    <Content Include="Resources\Templates\ProvisioningTemplate-2016-05-Sample-02.xml" />
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-Valid-XInclude-01.xml" />
     <Content Include="Resources\Templates\ProvisioningTemplate-2015-05-XInclude-PropertyBags.xml" />
     <Content Include="Resources\TestDefault.aspx">

--- a/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-01.xml
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-01.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
-<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2015/05/ProvisioningSchema">
-  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=1.4.815.0, Culture=neutral, PublicKeyToken=null" />
+<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema">
+  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.6.1608.0, Culture=neutral, PublicKeyToken=null" />
   <pnp:Templates ID="CONTAINER-SPECIALTEAM">
     <pnp:ProvisioningTemplate ID="SPECIALTEAM" Version="1">
       <pnp:SitePolicy>HBI</pnp:SitePolicy>
+      <pnp:WebSettings NoCrawl="false" SiteLogo="Resources/Themes/Contoso/contosologo.png" AlternateCSS="Resources/Themes/Contoso/Contoso.css" MasterPageUrl="seattle.master" />
       <pnp:PropertyBagEntries>
-        <pnp:PropertyBagEntry Key="KEY1" Value="value1" />
-        <pnp:PropertyBagEntry Key="KEY2" Value="value2" />
+        <pnp:PropertyBagEntry Key="KEY1" Value="value1" Overwrite="false" />
+        <pnp:PropertyBagEntry Key="KEY2" Value="value2" Overwrite="false" />
       </pnp:PropertyBagEntries>
-      <pnp:Security>
+      <pnp:Security ClearSubscopes="false">
         <pnp:AdditionalAdministrators>
           <pnp:User Name="user@contoso.com" />
           <pnp:User Name="U_SHAREPOINT_ADMINS" />
@@ -25,9 +26,10 @@
           <pnp:User Name="user@contoso.com" />
           <pnp:User Name="U_SHAREPOINT_ADMINS" />
         </pnp:AdditionalVisitors>
+        <pnp:Permissions />
       </pnp:Security>
       <pnp:SiteFields>
-        <Field ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Type="Text" Name="ProjectID" DisplayName="Project ID" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" />
+        <Field ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Type="Text" Name="ProjectID" DisplayName="Project ID" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" Required="TRUE" />
         <Field ID="{B01B3DBC-4630-4ED1-B5BA-321BC7841E3D}" Type="Text" Name="ProjectName" DisplayName="Project Name" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" />
         <Field ID="{A5DE9600-B7A6-42DD-A05E-10D4F1500208}" Type="Text" Name="ProjectManager" DisplayName="Project Manager" Group="My Columns" MaxLength="255" AllowDeletion="TRUE" />
         <Field ID="{F1A1715E-6C52-40DE-8403-E9AAFD0470D0}" Type="Text" Name="DocumentDescription" DisplayName="Document Description" Group="My Columns " MaxLength="255" AllowDeletion="TRUE" />
@@ -35,7 +37,7 @@
       <pnp:ContentTypes>
         <pnp:ContentType ID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E" Name="General Project Document" Description="General Project Document Content Type" Group="Base Foundation Content Types">
           <pnp:FieldRefs>
-            <pnp:FieldRef ID="23203e97-3bfe-40cb-afb4-07aa2b86bf45" />
+            <pnp:FieldRef ID="23203e97-3bfe-40cb-afb4-07aa2b86bf45" Required="true" />
             <pnp:FieldRef ID="b01b3dbc-4630-4ed1-b5ba-321bc7841e3d" />
             <pnp:FieldRef ID="a5de9600-b7a6-42dd-a05e-10d4f1500208" />
             <pnp:FieldRef ID="f1a1715e-6c52-40de-8403-e9aafd0470d0" />
@@ -43,7 +45,7 @@
         </pnp:ContentType>
       </pnp:ContentTypes>
       <pnp:Lists>
-        <pnp:ListInstance Title="Project Documents" Description="Project Documents are stored here" DocumentTemplate="" TemplateType="101" Url="Lists/ProjectDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="10" RemoveExistingContentTypes="true">
+        <pnp:ListInstance Title="Project Documents" Description="Project Documents are stored here" DocumentTemplate="" TemplateType="101" Url="Lists/ProjectDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="10" DraftVersionVisibility="0" RemoveExistingContentTypes="true">
           <pnp:ContentTypeBindings>
             <pnp:ContentTypeBinding ContentTypeID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E" Default="true" />
           </pnp:ContentTypeBindings>
@@ -84,15 +86,15 @@
       </pnp:Features>
       <pnp:CustomActions>
         <pnp:SiteCustomActions>
-          <pnp:CustomAction Name="CA_SITE_SETTINGS_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="Site Classification" Sequence="1000" Rights="31" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}">
+          <pnp:CustomAction Name="CA_SITE_SETTINGS_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="Site Classification" Sequence="1000" Rights="ManageWeb" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
-          <pnp:CustomAction Name="CA_SUBSITE_OVERRIDE" Description="Override new sub-site link" Location="ScriptLink" Title="SubSiteOveride" Sequence="100" Rights="0" ScriptSrc="~site/PnP_Provisioning_JS/PnP_EmbeddedJS.js">
+          <pnp:CustomAction Name="CA_SUBSITE_OVERRIDE" Description="Override new sub-site link" Location="ScriptLink" Title="SubSiteOveride" Sequence="100" Rights="" ScriptSrc="~site/PnP_Provisioning_JS/PnP_EmbeddedJS.js" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
         </pnp:SiteCustomActions>
         <pnp:WebCustomActions>
-          <pnp:CustomAction Name="CA_WEB_DOCLIB_MENU_SAMPLE" Description="Document Library Custom Menu" Group="ActionsMenu" Location="Microsoft.SharePoint.StandardMenu" Title="DocLib Custom Menu" Sequence="100" Rights="0" Url="/_layouts/CustomActionsHello.aspx?ActionsMenu">
+          <pnp:CustomAction Name="CA_WEB_DOCLIB_MENU_SAMPLE" Description="Document Library Custom Menu" Group="ActionsMenu" Location="Microsoft.SharePoint.StandardMenu" Title="DocLib Custom Menu" Sequence="100" Rights="" Url="/_layouts/CustomActionsHello.aspx?ActionsMenu" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
         </pnp:WebCustomActions>
@@ -100,7 +102,7 @@
       <pnp:Files>
         <pnp:File Src="/Resources/Files/SAMPLE.js" Folder="SAMPLE" />
       </pnp:Files>
-      <pnp:ComposedLook Name="Contoso" ColorFile="Resources/Themes/Contoso/contoso.spcolor" FontFile="Resources/Themes/Contoso/contoso.spfont" BackgroundFile="Resources/Themes/Contoso/contosobg.jpg" MasterPage="seattle.master" SiteLogo="Resources/Themes/Contoso/contosologo.png" AlternateCSS="Resources/Themes/Contoso/Contoso.css" Version="1" />
+      <pnp:ComposedLook Name="Contoso" ColorFile="Resources/Themes/Contoso/contoso.spcolor" FontFile="Resources/Themes/Contoso/contoso.spfont" BackgroundFile="Resources/Themes/Contoso/contosobg.jpg" Version="1" />
       <pnp:Providers>
         <pnp:Provider HandlerType="MyType, Sample">
           <pnp:Configuration><![CDATA[Some custom text that is not XML and that can contain symbols like >, or <, or &, or whatever else.]]></pnp:Configuration>

--- a/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-02.xml
+++ b/Core/OfficeDevPnP.Core.Tests/Resources/Templates/ProvisioningTemplate-2016-05-Sample-02.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
-<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2015/05/ProvisioningSchema">
-  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=1.4.815.0, Culture=neutral, PublicKeyToken=null" />
+<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2016/05/ProvisioningSchema">
+  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=2.6.1608.0, Culture=neutral, PublicKeyToken=null" />
   <pnp:Templates ID="CONTAINER-SPECIALTEAM">
     <pnp:ProvisioningTemplate ID="SPECIALTEAM" Version="1">
       <pnp:SitePolicy>HBI</pnp:SitePolicy>
+      <pnp:WebSettings NoCrawl="false" SiteLogo="SiteAssets/Logo.png" AlternateCSS="Resources/Themes/Contoso/Contoso.css" MasterPageUrl="_catalogs/MasterPage/CustomMaster.master" />
       <pnp:PropertyBagEntries>
-        <pnp:PropertyBagEntry Key="KEY1" Value="value1" />
-        <pnp:PropertyBagEntry Key="KEY2" Value="value2" />
+        <pnp:PropertyBagEntry Key="KEY1" Value="value1" Overwrite="false" />
+        <pnp:PropertyBagEntry Key="KEY2" Value="value2" Overwrite="false" />
       </pnp:PropertyBagEntries>
-      <pnp:Security>
+      <pnp:Security ClearSubscopes="false">
         <pnp:AdditionalAdministrators>
           <pnp:User Name="user@contoso.com" />
           <pnp:User Name="U_SHAREPOINT_ADMINS" />
@@ -25,6 +26,7 @@
           <pnp:User Name="user@contoso.com" />
           <pnp:User Name="U_SHAREPOINT_ADMINS" />
         </pnp:AdditionalVisitors>
+        <pnp:Permissions />
       </pnp:Security>
       <pnp:SiteFields>
         <Field ID="{23203E97-3BFE-40CB-AFB4-07AA2B86BF45}" Type="Text" Name="ProjectID" DisplayName="Project ID" Group="Base.Foundation.Columns" MaxLength="255" AllowDeletion="TRUE" />
@@ -43,12 +45,12 @@
         </pnp:ContentType>
       </pnp:ContentTypes>
       <pnp:Lists>
-        <pnp:ListInstance Title="Project Documents" Description="Project Documents are stored here" DocumentTemplate="" OnQuickLaunch="true" TemplateType="101" Url="Lists/ProjectDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="0">
+        <pnp:ListInstance Title="Project Documents" Description="Project Documents are stored here" DocumentTemplate="" OnQuickLaunch="true" TemplateType="101" Url="Lists/ProjectDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="0" DraftVersionVisibility="0">
           <pnp:ContentTypeBindings>
             <pnp:ContentTypeBinding ContentTypeID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E" Default="true" />
           </pnp:ContentTypeBindings>
         </pnp:ListInstance>
-        <pnp:ListInstance Title="General Documents" Description="Project Documents are stored here" DocumentTemplate="" OnQuickLaunch="true" TemplateType="101" Url="Lists/GeneralDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="0" RemoveExistingContentTypes="true">
+        <pnp:ListInstance Title="General Documents" Description="Project Documents are stored here" DocumentTemplate="" OnQuickLaunch="true" TemplateType="101" Url="Lists/GeneralDocuments" EnableVersioning="true" MinorVersionLimit="0" MaxVersionLimit="0" DraftVersionVisibility="0" RemoveExistingContentTypes="true">
           <pnp:ContentTypeBindings>
             <pnp:ContentTypeBinding ContentTypeID="0x01005D4F34E4BE7F4B6892AEBE088EDD215E" Default="true" />
           </pnp:ContentTypeBindings>
@@ -69,15 +71,15 @@
       </pnp:Features>
       <pnp:CustomActions>
         <pnp:SiteCustomActions>
-          <pnp:CustomAction Name="CA_SITE_SETTINGS_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="Site Classification" Sequence="1000" Rights="31" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}">
+          <pnp:CustomAction Name="CA_SITE_SETTINGS_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="Site Classification" Sequence="1000" Rights="ManageWeb" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
-          <pnp:CustomAction Name="CA_STDMENU_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteActions" Location="Microsoft.SharePoint.StandardMenu" Title="Site Classification" Sequence="1000" Rights="31" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}">
+          <pnp:CustomAction Name="CA_STDMENU_SITECLASSIFICATION" Description="Site Classification Application" Group="SiteActions" Location="Microsoft.SharePoint.StandardMenu" Title="Site Classification" Sequence="1000" Rights="ManageWeb" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
         </pnp:SiteCustomActions>
         <pnp:WebCustomActions>
-          <pnp:CustomAction Name="CA_SUBSITE_OVERRIDE" Description="Override new sub-site link" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="SubSite Overide" Sequence="1000" Rights="31" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}">
+          <pnp:CustomAction Name="CA_SUBSITE_OVERRIDE" Description="Override new sub-site link" Group="SiteTasks" Location="Microsoft.SharePoint.SiteSettings" Title="SubSite Overide" Sequence="1000" Rights="ManageWeb" Url="https://spmanaged.azurewebsites.net/pages/index.aspx?SPHostUrl={0}" RegistrationType="None">
             <pnp:CommandUIExtension />
           </pnp:CustomAction>
         </pnp:WebCustomActions>
@@ -89,7 +91,7 @@
         <pnp:File Src="Custom.spcolor" Folder="_catalogs/Theme/15" Overwrite="true" />
         <pnp:File Src="Custom.spfont" Folder="_catalogs/Theme/15" Overwrite="true" />
       </pnp:Files>
-      <pnp:ComposedLook Name="Custom Look" ColorFile="_catalogs/Theme/15/Custom.spcolor" FontFile="_catalogs/Theme/15/Custom.spfont" BackgroundFile="Resources/Themes/Contoso/contosobg.jpg" MasterPage="_catalogs/MasterPage/CustomMaster.master" SiteLogo="SiteAssets/Logo.png" AlternateCSS="Resources/Themes/Contoso/Contoso.css" Version="1" />
+      <pnp:ComposedLook Name="Custom Look" ColorFile="_catalogs/Theme/15/Custom.spcolor" FontFile="_catalogs/Theme/15/Custom.spfont" BackgroundFile="Resources/Themes/Contoso/contosobg.jpg" Version="1" />
       <pnp:Providers>
         <pnp:Provider Enabled="true" HandlerType="OfficeDev.PnP.Provisioning.Providers.FakeProvider, OfficeDev.PnP.Provisioning.Providers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
           <pnp:Configuration>

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/ITemplateProviderExtension.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/ITemplateProviderExtension.cs
@@ -1,0 +1,70 @@
+﻿using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.Providers
+{
+    /// <summary>
+    /// Interface for extending the XMLTemplateProvider while retrieving a template
+    /// </summary>
+    public interface ITemplateProviderExtension
+    {
+        /// <summary>
+        /// Initialization method to setup the extension object
+        /// </summary>
+        /// <param name="settings"></param>
+        void Initialize(Object settings);
+
+        /// <summary>
+        /// Method invoked before deserializing the template from the source repository
+        /// </summary>
+        /// <param name="stream">The source stream</param>
+        /// <returns>The resulting stream, after pre-processing</returns>
+        Stream PreProcessGetTemplate(Stream stream);
+
+        /// <summary>
+        /// Method invoked after deserializing the template from the source repository
+        /// </summary>
+        /// <param name="template">The just deserialized template</param>
+        /// <returns>The resulting template, after post-processing</returns>
+        ProvisioningTemplate PostProcessGetTemplate(ProvisioningTemplate template);
+
+        /// <summary>
+        /// Method invoked before serializing the template and before it is saved onto the target repository
+        /// </summary>
+        /// <param name="template">The template that is going to be serialized</param>
+        /// <returns>The resulting template, after pre-processing</returns>
+        ProvisioningTemplate PreProcessSaveTemplate(ProvisioningTemplate template);
+
+        /// <summary>
+        /// Method invoked after serializing the template and before it is saved onto the target repository
+        /// </summary>
+        /// <param name="stream">The source stream</param>
+        /// <returns>The resulting stream, after pre-processing</returns>
+        Stream PostProcessSaveTemplate(Stream stream);
+
+        /// <summary>
+        /// Declares whether the object supports pre-processing during GetTemplate
+        /// </summary>
+        Boolean SupportsGetTemplatePreProcessing { get; }
+
+        /// <summary>
+        /// Declares whether the object supports post-processing during GetTemplate
+        /// </summary>
+        Boolean SupportsGetTemplatePostProcessing { get; }
+
+        /// <summary>
+        /// Declares whether the object supports pre-processing during SaveTemplate
+        /// </summary>
+        Boolean SupportsSaveTemplatePreProcessing { get; }
+
+        /// <summary>
+        /// Declares whether the object supports post-processing during SaveTemplate
+        /// </summary>
+        Boolean SupportsSaveTemplatePostProcessing { get; }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/TemplateProviderBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/TemplateProviderBase.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using System.IO;
+using System.Linq;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.Providers
 {
@@ -87,21 +89,138 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers
 
         public abstract ProvisioningTemplate GetTemplate(string uri);
 
+        public abstract ProvisioningTemplate GetTemplate(string uri, ITemplateProviderExtension[] extensions);
+
         public abstract ProvisioningTemplate GetTemplate(string uri, string identifier);
 
         public abstract ProvisioningTemplate GetTemplate(string uri, ITemplateFormatter formatter);
 
         public abstract ProvisioningTemplate GetTemplate(string uri, string identifier, ITemplateFormatter formatter);
 
+        public abstract ProvisioningTemplate GetTemplate(string uri, string identifier, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions);
+        
         public abstract void Save(ProvisioningTemplate template);
+
+        public abstract void Save(ProvisioningTemplate template, ITemplateProviderExtension[] extensions);
 
         public abstract void Save(ProvisioningTemplate template, ITemplateFormatter formatter);
 
+        public abstract void Save(ProvisioningTemplate template, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions);
+
         public abstract void SaveAs(ProvisioningTemplate template, string uri);
+
+        public abstract void SaveAs(ProvisioningTemplate template, string uri, ITemplateProviderExtension[] extensions);
 
         public abstract void SaveAs(ProvisioningTemplate template, string uri, ITemplateFormatter formatter);
 
+        public abstract void SaveAs(ProvisioningTemplate template, string uri, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions);
+
         public abstract void Delete(string uri);
+
+        #endregion
+
+        #region Protected methods
+
+        protected virtual void SaveToConnector(ProvisioningTemplate template, string uri, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions)
+        {
+            if (String.IsNullOrEmpty(template.Id))
+            {
+                template.Id = Path.GetFileNameWithoutExtension(uri);
+            }
+
+            template = PreProcessSaveTemplateExtensions(extensions, template);
+
+            using (var stream = formatter.ToFormattedTemplate(template))
+            {
+                using (var processedStream = PostProcessSaveTemplateExtensions(extensions, stream))
+                {
+                    this.Connector.SaveFileStream(uri, processedStream);
+                }
+            }
+
+            if (this.Connector is ICommitableFileConnector)
+            {
+                ((ICommitableFileConnector)this.Connector).Commit();
+            }
+        }
+
+        /// <summary>
+        /// This method is invoked before calling the formatter to serialize the template
+        /// </summary>
+        /// <param name="extensions">The list of custom extensions</param>
+        /// <param name="template">The template to serialize</param>
+        /// <returns>The template eventually updated by the custom extensions</returns>
+        protected virtual ProvisioningTemplate PreProcessSaveTemplateExtensions(ITemplateProviderExtension[] extensions, ProvisioningTemplate template)
+        {
+            ProvisioningTemplate result = template;
+
+            // Handle any pre-processing extension during Save
+            if (extensions != null && extensions.Length > 0)
+            {
+                foreach (var extension in extensions.Where(e => e.SupportsSaveTemplatePreProcessing))
+                {
+                    result = extension.PreProcessSaveTemplate(result);
+                }
+            }
+
+            return (result);
+        }
+
+        protected Stream PostProcessSaveTemplateExtensions(ITemplateProviderExtension[] extensions, Stream stream)
+        {
+            // Handle any pre-processing extension
+            if (extensions != null && extensions.Length > 0)
+            {
+                foreach (var extension in extensions.Where(e => e.SupportsSaveTemplatePostProcessing))
+                {
+                    var temp = new MemoryStream();
+                    stream.Seek(0, SeekOrigin.Begin);
+                    stream.CopyTo(temp);
+
+                    temp.Seek(0, SeekOrigin.Begin);
+                    stream = extension.PostProcessSaveTemplate(temp);
+                    stream.Seek(0, SeekOrigin.Begin);
+                }
+            }
+
+            return (stream);
+        }
+
+        protected Stream PreProcessGetTemplateExtensions(ITemplateProviderExtension[] extensions, Stream stream)
+        {
+            // Handle any pre-processing extension
+            if (extensions != null && extensions.Length > 0)
+            {
+                foreach (var extension in extensions.Where(e => e.SupportsGetTemplatePreProcessing))
+                {
+                    var temp = new MemoryStream();
+                    stream.Seek(0, SeekOrigin.Begin);
+                    stream.CopyTo(temp);
+
+                    temp.Seek(0, SeekOrigin.Begin);
+                    stream = extension.PreProcessGetTemplate(temp);
+                    stream.Seek(0, SeekOrigin.Begin);
+                }
+            }
+
+            return (stream);
+        }
+
+        protected ProvisioningTemplate PostProcessGetTemplateExtensions(ITemplateProviderExtension[] extensions, ProvisioningTemplate template)
+        {
+            ProvisioningTemplate result = template;
+
+            // Handle any post-processing extension
+            if (extensions != null && extensions.Length > 0)
+            {
+                foreach (var extension in extensions.Where(e => e.SupportsGetTemplatePostProcessing))
+                {
+                    result = extension.PostProcessGetTemplate(result);
+                }
+            }
+
+            return (result);
+        }
 
         #endregion
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLTemplateProvider.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLTemplateProvider.cs
@@ -15,7 +15,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
     /// </summary>
     public abstract class XMLTemplateProvider : TemplateProviderBase
     {
-
         #region Constructor
         protected XMLTemplateProvider()
             : base()
@@ -74,16 +73,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         public override ProvisioningTemplate GetTemplate(string uri)
         {
-            var formatter = new XMLPnPSchemaFormatter();
-            formatter.Initialize(this);
-            return (this.GetTemplate(uri, null, formatter));
+            return (this.GetTemplate(uri, (ITemplateProviderExtension[])null));
+        }
+
+        public override ProvisioningTemplate GetTemplate(string uri, ITemplateProviderExtension[] extensions = null)
+        {
+            return (this.GetTemplate(uri, null, null, extensions));
         }
 
         public override ProvisioningTemplate GetTemplate(string uri, string identifier)
         {
-            var formatter = new XMLPnPSchemaFormatter();
-            formatter.Initialize(this);
-            return (this.GetTemplate(uri, identifier, formatter));
+            return (this.GetTemplate(uri, identifier, null));
         }
 
         public override ProvisioningTemplate GetTemplate(string uri, ITemplateFormatter formatter)
@@ -93,11 +93,22 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         public override ProvisioningTemplate GetTemplate(string uri, string identifier, ITemplateFormatter formatter)
         {
+            return (this.GetTemplate(uri, identifier, formatter, null));
+        }
+
+        public override ProvisioningTemplate GetTemplate(string uri, string identifier, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions = null)
+        {
             if (String.IsNullOrEmpty(uri))
             {
                 throw new ArgumentException("uri");
             }
-            
+
+            if (formatter == null)
+            {
+                formatter = new XMLPnPSchemaFormatter();
+                formatter.Initialize(this);
+            }
+
             // Get the XML document from a File Stream
             Stream stream = this.Connector.GetFileStream(uri);
 
@@ -106,11 +117,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                 throw new ApplicationException(string.Format(CoreResources.Provisioning_Formatter_Invalid_Template_URI, uri));
             }
 
+            // Handle any pre-processing extension
+            stream = PreProcessGetTemplateExtensions(extensions, stream);
+
             //Resolve xml includes if any
             stream = ResolveXIncludes(stream);
 
             // And convert it into a ProvisioningTemplate
             ProvisioningTemplate provisioningTemplate = formatter.ToProvisioningTemplate(stream, identifier);
+
+            // Handle any post-processing extension
+            provisioningTemplate = PostProcessGetTemplateExtensions(extensions, provisioningTemplate);
 
             // Store the identifier of this template, is needed for latter save operation
             this.Uri = uri;
@@ -120,27 +137,40 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
 
         public override void Save(ProvisioningTemplate template)
         {
-            var formatter = new XMLPnPSchemaFormatter();
-            this.Save(template, formatter);
+            this.Save(template, (ITemplateProviderExtension[])null);
+        }
+
+        public override void Save(ProvisioningTemplate template, ITemplateProviderExtension[] extensions = null)
+        {
+            this.Save(template, null, extensions);
         }
 
         public override void Save(ProvisioningTemplate template, ITemplateFormatter formatter)
         {
-            if (template == null)
-            {
-                throw new ArgumentNullException("template");
-            }
+            this.Save(template, formatter, null);
+        }
 
-            SaveToConnector(template, this.Uri, formatter);
+        public override void Save(ProvisioningTemplate template, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions = null)
+        {
+            this.SaveAs(template, this.Uri, formatter, extensions);
         }
 
         public override void SaveAs(ProvisioningTemplate template, string uri)
         {
-            var formatter = new XMLPnPSchemaFormatter();
-            this.SaveAs(template, uri, formatter);
+            this.SaveAs(template, uri, (ITemplateProviderExtension[])null);
+        }
+
+        public override void SaveAs(ProvisioningTemplate template, string uri, ITemplateProviderExtension[] extensions)
+        {
+            this.SaveAs(template, uri, null, extensions);
         }
 
         public override void SaveAs(ProvisioningTemplate template, string uri, ITemplateFormatter formatter)
+        {
+            this.SaveAs(template, uri, formatter, null);
+        }
+
+        public override void SaveAs(ProvisioningTemplate template, string uri, ITemplateFormatter formatter, ITemplateProviderExtension[] extensions)
         {
             if (template == null)
             {
@@ -152,7 +182,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                 throw new ArgumentException("uri");
             }
 
-            SaveToConnector(template, uri, formatter);
+            if (formatter == null)
+            {
+                formatter = new XMLPnPSchemaFormatter();
+            }
+
+            SaveToConnector(template, uri, formatter, extensions);
         }
 
         public override void Delete(string uri)
@@ -168,24 +203,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
         #endregion
 
         #region Helper methods
-
-        private void SaveToConnector(ProvisioningTemplate template, string uri, ITemplateFormatter formatter)
-        {
-            if (String.IsNullOrEmpty(template.Id))
-            {
-                template.Id = Path.GetFileNameWithoutExtension(uri);
-            }
-
-            using (var stream = formatter.ToFormattedTemplate(template))
-            {
-                this.Connector.SaveFileStream(uri, stream);
-            }
-
-            if (this.Connector is ICommitableFileConnector)
-            {
-                ((ICommitableFileConnector)this.Connector).Commit();
-            }
-        }
 
         private Stream ResolveXIncludes(Stream stream)
         {

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -638,6 +638,7 @@
     <Compile Include="Framework\Provisioning\Providers\Json\JsonTemplateProvider.cs" />
     <Compile Include="Framework\Provisioning\Providers\TemplateProviderBase.cs" />
     <Compile Include="Framework\Provisioning\Providers\Xml\IXMLSchemaFormatter.cs" />
+    <Compile Include="Framework\Provisioning\Providers\ITemplateProviderExtension.cs" />
     <Compile Include="Framework\Provisioning\Providers\Xml\ProvisioningSchema-2015-03.cs">
       <DependentUpon>ProvisioningSchema-2015-03.xsd</DependentUpon>
     </Compile>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | nothing

#### What's in this Pull Request?

Added the capability to register object that implement interface ITemplateProviderExtension in order to handle pre/post-processing during template load/save operations. 
Look at test XMLEncryptionTest to see how to use it in code (we will add support for PowerShell, too) and to see an example about how to do XML Encryption of a provisioning template.