### PR TITLE
Escape tokens to support special characters

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using System;
 
 namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
@@ -73,6 +74,72 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(currentUserLoginName == currentUser.LoginName);
                 Guid outGuid;
                 Assert.IsTrue(Guid.TryParse(guid, out outGuid));
+            }
+        }
+
+        [TestMethod]
+        public void RegexSpecialCharactersTests()
+        {
+            using (var ctx = TestCommon.CreateClientContext())
+            {
+                ctx.Load(ctx.Web, w => w.Id, w => w.ServerRelativeUrl, w => w.Title, w => w.AssociatedOwnerGroup.Title, w => w.AssociatedMemberGroup.Title, w => w.AssociatedVisitorGroup.Title);
+                ctx.Load(ctx.Site, s => s.ServerRelativeUrl);
+
+                ctx.ExecuteQueryRetry();
+
+                var currentUser = ctx.Web.EnsureProperty(w => w.CurrentUser);
+
+                ProvisioningTemplate template = new ProvisioningTemplate();
+                template.Parameters.Add("test(T)", "test");
+
+                var parser = new TokenParser(ctx.Web, template);
+
+                var web = ctx.Web;
+
+                var contentTypeName = "Test CT (TC) [TC].$";
+                var contentTypeId = "0x010801006439AECCDEAE4db2A422A3A04C79CC83";
+                var listGuid = Guid.NewGuid();
+                var listTitle = @"List (\,*+?|{[()^$.#";
+                var listUrl = "Lists/TestList";
+                var webPartTitle = @"Webpart (\*+?|{[()^$.#";
+                var webPartId = Guid.NewGuid();
+                var termSetName = @"Test TermSet (\*+?{[()^$.#";
+                var termGroupName = @"Group Name (\*+?{[()^$.#";
+                var termStoreName = @"Test TermStore (\*+?{[()^$.#";
+                var termSetId = Guid.NewGuid();
+                var termStoreId = Guid.NewGuid();
+
+
+                // Use fake data
+                parser.AddToken(new ContentTypeIdToken(web, contentTypeName, contentTypeId));
+                parser.AddToken(new ListIdToken(web, listTitle, listGuid));
+                parser.AddToken(new ListUrlToken(web, listTitle, listUrl));
+                parser.AddToken(new WebPartIdToken(web, webPartTitle, webPartId));
+                parser.AddToken(new TermSetIdToken(web, termGroupName, termSetName, termSetId));
+                parser.AddToken(new TermStoreIdToken(web, termStoreName, termStoreId));
+
+                var resolvedContentTypeId = parser.ParseString(string.Format("{{contenttypeid:{0}}}", contentTypeName));
+                var resolvedListId = parser.ParseString(string.Format("{{listid:{0}}}", listTitle));
+                var resolvedListUrl = parser.ParseString(string.Format("{{listurl:{0}}}", listTitle));
+
+                var parameterExpectedResult = string.Format("abc{0}/test", "test");
+                var parameterTest1 = parser.ParseString("abc{parameter:TEST(T)}/test");
+                var parameterTest2 = parser.ParseString("abc{$test(T)}/test");
+                var resolvedWebpartId = parser.ParseString(string.Format("{{webpartid:{0}}}", webPartTitle));
+                var resolvedTermSetId = parser.ParseString(string.Format("{{termsetid:{0}:{1}}}", termGroupName, termSetName));
+                var resolvedTermStoreId = parser.ParseString(string.Format("{{termstoreid:{0}}}", termStoreName));
+
+
+                Assert.IsTrue(contentTypeId == resolvedContentTypeId);
+                Assert.IsTrue(listUrl == resolvedListUrl);
+                Guid outGuid;
+                Assert.IsTrue(Guid.TryParse(resolvedListId, out outGuid));
+                Assert.IsTrue(parameterTest1 == parameterExpectedResult);
+                Assert.IsTrue(parameterTest2 == parameterExpectedResult);
+                Assert.IsTrue(Guid.TryParse(resolvedWebpartId, out outGuid));
+                Assert.IsTrue(Guid.TryParse(resolvedTermSetId, out outGuid));
+                Assert.IsTrue(Guid.TryParse(resolvedTermStoreId, out outGuid));
+
             }
         }
     }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ContentTypeIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ContentTypeIdToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private string _contentTypeId = null;
         public ContentTypeIdToken(Web web, string name, string contenttypeid)
-            : base(web, string.Format("{{contenttypeid:{0}}}", name))
+            : base(web, string.Format("{{contenttypeid:{0}}}", Regex.Escape(name)))
         {
             _contentTypeId = contenttypeid;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListIdToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private string _listId = null;
         public ListIdToken(Web web, string name, Guid listid)
-            : base(web, string.Format("{{listid:{0}}}", name))
+            : base(web, string.Format("{{listid:{0}}}", Regex.Escape(name)))
         {
             _listId = listid.ToString();
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListUrlToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ListUrlToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private string _listUrl = null;
         public ListUrlToken(Web web, string name, string url)
-            : base(web, string.Format("{{listurl:{0}}}", name))
+            : base(web, string.Format("{{listurl:{0}}}", Regex.Escape(name)))
         {
             _listUrl = url;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
@@ -2,6 +2,7 @@ using Microsoft.SharePoint.Client;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -9,7 +10,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private List<ResourceEntry> _resourceEntries;
         public LocalizationToken(Web web, string key, List<ResourceEntry> resourceEntries)
-            : base(web, string.Format("{{loc:{0}}}", key), string.Format("{{localize:{0}}}", key), string.Format("{{localization:{0}}}", key), string.Format("{{resource:{0}}}", key), string.Format("{{res:{0}}}", key))
+            : base(web, string.Format("{{loc:{0}}}", Regex.Escape(key)), string.Format("{{localize:{0}}}", Regex.Escape(key)), string.Format("{{localization:{0}}}", Regex.Escape(key)), string.Format("{{resource:{0}}}", Regex.Escape(key)), string.Format("{{res:{0}}}", Regex.Escape(key)))
         {
             _resourceEntries = resourceEntries;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ParameterToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ParameterToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private readonly string _value = null;
         public ParameterToken(Web web, string name, string value)
-            : base(web, string.Format("{{parameter:{0}}}", name), string.Format("{{\\${0}}}", name))
+            : base(web, string.Format("{{parameter:{0}}}", Regex.Escape(name)), string.Format("{{\\${0}}}", Regex.Escape(name)))
         {
             _value = value;
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermSetIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermSetIdToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private readonly string _value = null;
         public TermSetIdToken(Web web, string groupName, string termsetName, Guid id)
-            : base(web, string.Format("{{termsetid:{0}:{1}}}", groupName, termsetName))
+            : base(web, string.Format("{{termsetid:{0}:{1}}}", Regex.Escape(groupName), Regex.Escape(termsetName)))
         {
             _value = id.ToString();
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermStoreIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermStoreIdToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private readonly string _value = null;
         public TermStoreIdToken(Web web, string storeName, Guid id)
-            : base(web, string.Format("{{termstoreid:{0}}}", storeName))
+            : base(web, string.Format("{{termstoreid:{0}}}", Regex.Escape(storeName)))
         {
             _value = id.ToString();
         }

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/WebPartIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/WebPartIdToken.cs
@@ -1,5 +1,6 @@
 using Microsoft.SharePoint.Client;
 using System;
+using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -7,7 +8,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitio
     {
         private string _webpartId = null;
         public WebPartIdToken(Web web, string name, Guid webpartid)
-            : base(web, string.Format("{{webpartid:{0}}}", name))
+            : base(web, string.Format("{{webpartid:{0}}}", Regex.Escape(name)))
         {
             _webpartId = webpartid.ToString();
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

Some Token classes for the TokenParser have parameters (list name, content type name etc.) that were added to the token without any escaping. TokenParser then creates Regex from token and uses this regex to find the matches in parsed strings.

If those parameters contained special characters that are part of Regex syntax (e.g. "{listid:ListName (ABBR)}" contains brackets ), they got interpreted incorrectly and resulted in tokens not being resolved.

This pull request fixes the issue by doing Regex.Escape. It also contains test to verify the scenarios.