### PR TITLE
Possible solution to Issue #698 (Custom ProvisiningExtensibilityHandl…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Extensibility/ExtensibilityManager.cs
@@ -25,7 +25,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Extensibility
         /// <exception cref="ExtensiblityPipelineException"></exception>
         /// <exception cref="ArgumentException">Provider.Assembly or Provider.Type is NullOrWhiteSpace></exception>
         /// <exception cref="ArgumentNullException">ClientContext is Null></exception>
-        public IEnumerable<TokenDefinition> ExecuteTokenProviderCallOut(ClientContext ctx, Provider provider, ProvisioningTemplate template)
+        public IEnumerable<TokenDefinition> ExecuteTokenProviderCallOut(ClientContext ctx, ExtensibilityHandler provider, ProvisioningTemplate template)
         {
             var _loggingSource = "OfficeDevPnP.Core.Framework.Provisioning.Extensibility.ExtensibilityManager.ExecuteTokenProviderCallOut";
 

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityHandlers.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityHandlers.cs
@@ -25,7 +25,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             using (var scope = new PnPMonitoredScope(this.Name))
             {
                 var context = web.Context as ClientContext;
-                foreach (var handler in template.ExtensibilityHandlers.Union(template.Providers).OfType<Provider>())
+                foreach (var handler in template.ExtensibilityHandlers.Union(applyingInformation.ExtensibilityHandlers))
                 {
                     if (handler.Enabled)
                     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| Related issues?  | fixes #698 

#### What's in this Pull Request?

This PR is a propossed solution for issue #698 

This code was wrong, as doing the Union with OfType<Provider> resulted in an empty collection, as the custom handler was implmenting the new interface.

```c#
foreach (var handler in template.ExtensibilityHandlers.Union(template.Providers).OfType<Provider>()
```

Also, in the *ExtensibilityManager* class, there was an issue with this header:

```c#
public IEnumerable<TokenDefinition> ExecuteTokenProviderCallOut(ClientContext ctx, Provider provider, ProvisioningTemplate template)
```
as the *Provider* object was wrong, and it has to be a *ExtensibilityHandler* object.

I'm not checkeing if the custom Handler is using the new or the old interface here, as the Tokens thing is only supported by the new interface, so here we never hit with an old Provider object.

Hope that makes sense.

Thanks!