### PR TITLE
use isDirty for CommandUIExtension

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -165,7 +165,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             else
             {
                 // Required to allow for a delta action to blank out the CommandUIExtension attribute
-                existingCustomAction.CommandUIExtension = null;
+                if (existingCustomAction.CommandUIExtension != null)
+                {
+                    scope.LogPropertyUpdate("CommandUIExtension");
+                    existingCustomAction.CommandUIExtension = null;
+                    isDirty = true;
+                }
             }
 
             if (existingCustomAction.Description != customAction.Description)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | n/a

#### What's in this Pull Request?

CommandUIExtension updates should be treated like updating any other property.  This was causing the update to get sent in the next clientContext batch.


