### PR TITLE
Added GroupId token

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -16,7 +16,16 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
         {
             using (var ctx = TestCommon.CreateClientContext())
             {
-                ctx.Load(ctx.Web, w => w.Id, w => w.ServerRelativeUrl, w => w.Title, w => w.AssociatedOwnerGroup.Title, w => w.AssociatedMemberGroup.Title, w => w.AssociatedVisitorGroup.Title);
+                ctx.Load(ctx.Web, 
+                    w => w.Id, 
+                    w => w.ServerRelativeUrl, 
+                    w => w.Title,
+                    w => w.AssociatedOwnerGroup.Title, 
+                    w => w.AssociatedMemberGroup.Title, 
+                    w => w.AssociatedVisitorGroup.Title, 
+                    w => w.AssociatedOwnerGroup.Id,
+                    w => w.AssociatedMemberGroup.Id,
+                    w => w.AssociatedVisitorGroup.Id);
                 ctx.Load(ctx.Site, s => s.ServerRelativeUrl);
 
                 var masterCatalog = ctx.Web.GetCatalog((int)ListTemplateType.MasterPageCatalog);
@@ -28,6 +37,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 ctx.ExecuteQueryRetry();
 
                 var currentUser = ctx.Web.EnsureProperty(w => w.CurrentUser);
+
+
+                var ownerGroupName = ctx.Web.AssociatedOwnerGroup.Title;
 
 
                 ProvisioningTemplate template = new ProvisioningTemplate();
@@ -53,15 +65,19 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 var currentUserLoginName = parser.ParseString("{currentuserloginname}");
                 var currentUserFullName = parser.ParseString("{currentuserfullname}");
                 var guid = parser.ParseString("{guid}");
+                var associatedOwnerGroupId = parser.ParseString("{groupid:associatedownergroup}");
+                var associatedMemberGroupId = parser.ParseString("{groupid:associatedmembergroup}");
+                var associatedVisitorGroupId = parser.ParseString("{groupid:associatedvisitorgroup}");
+                var groupId = parser.ParseString($"{{groupid:{ownerGroupName}}}");
 
-                Assert.IsTrue(site1 == string.Format("{0}/test", ctx.Web.ServerRelativeUrl));
-                Assert.IsTrue(site2 == string.Format("{0}/test", ctx.Web.ServerRelativeUrl));
-                Assert.IsTrue(sitecol1 == string.Format("{0}/test", ctx.Site.ServerRelativeUrl));
-                Assert.IsTrue(sitecol2 == string.Format("{0}/test", ctx.Site.ServerRelativeUrl));
-                Assert.IsTrue(masterUrl1 == string.Format("{0}/test", masterCatalog.RootFolder.ServerRelativeUrl));
-                Assert.IsTrue(masterUrl2 == string.Format("{0}/test", masterCatalog.RootFolder.ServerRelativeUrl));
-                Assert.IsTrue(themeUrl1 == string.Format("{0}/test", themesCatalog.RootFolder.ServerRelativeUrl));
-                Assert.IsTrue(themeUrl2 == string.Format("{0}/test", themesCatalog.RootFolder.ServerRelativeUrl));
+                Assert.IsTrue(site1 == $"{ctx.Web.ServerRelativeUrl}/test");
+                Assert.IsTrue(site2 == $"{ctx.Web.ServerRelativeUrl}/test");
+                Assert.IsTrue(sitecol1 == $"{ctx.Site.ServerRelativeUrl}/test");
+                Assert.IsTrue(sitecol2 == $"{ctx.Site.ServerRelativeUrl}/test");
+                Assert.IsTrue(masterUrl1 == $"{masterCatalog.RootFolder.ServerRelativeUrl}/test");
+                Assert.IsTrue(masterUrl2 == $"{masterCatalog.RootFolder.ServerRelativeUrl}/test");
+                Assert.IsTrue(themeUrl1 == $"{themesCatalog.RootFolder.ServerRelativeUrl}/test");
+                Assert.IsTrue(themeUrl2 == $"{themesCatalog.RootFolder.ServerRelativeUrl}/test");
                 Assert.IsTrue(parameterTest1 == "abctest/test");
                 Assert.IsTrue(parameterTest2 == "abctest/test");
                 Assert.IsTrue(associatedOwnerGroup == ctx.Web.AssociatedOwnerGroup.Title);
@@ -74,6 +90,11 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 Assert.IsTrue(currentUserLoginName == currentUser.LoginName);
                 Guid outGuid;
                 Assert.IsTrue(Guid.TryParse(guid, out outGuid));
+                Assert.IsTrue(int.Parse(associatedOwnerGroupId) == ctx.Web.AssociatedOwnerGroup.Id);
+                Assert.IsTrue(int.Parse(associatedMemberGroupId) == ctx.Web.AssociatedMemberGroup.Id);
+                Assert.IsTrue(int.Parse(associatedVisitorGroupId) == ctx.Web.AssociatedVisitorGroup.Id);
+                Assert.IsTrue(associatedOwnerGroupId == groupId);
+
             }
         }
 
@@ -118,16 +139,16 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 parser.AddToken(new TermSetIdToken(web, termGroupName, termSetName, termSetId));
                 parser.AddToken(new TermStoreIdToken(web, termStoreName, termStoreId));
 
-                var resolvedContentTypeId = parser.ParseString(string.Format("{{contenttypeid:{0}}}", contentTypeName));
-                var resolvedListId = parser.ParseString(string.Format("{{listid:{0}}}", listTitle));
-                var resolvedListUrl = parser.ParseString(string.Format("{{listurl:{0}}}", listTitle));
+                var resolvedContentTypeId = parser.ParseString($"{{contenttypeid:{contentTypeName}}}");
+                var resolvedListId = parser.ParseString($"{{listid:{listTitle}}}");
+                var resolvedListUrl = parser.ParseString($"{{listurl:{listTitle}}}");
 
-                var parameterExpectedResult = string.Format("abc{0}/test", "test");
+                var parameterExpectedResult = $"abc{"test"}/test";
                 var parameterTest1 = parser.ParseString("abc{parameter:TEST(T)}/test");
                 var parameterTest2 = parser.ParseString("abc{$test(T)}/test");
-                var resolvedWebpartId = parser.ParseString(string.Format("{{webpartid:{0}}}", webPartTitle));
-                var resolvedTermSetId = parser.ParseString(string.Format("{{termsetid:{0}:{1}}}", termGroupName, termSetName));
-                var resolvedTermStoreId = parser.ParseString(string.Format("{{termstoreid:{0}}}", termStoreName));
+                var resolvedWebpartId = parser.ParseString($"{{webpartid:{webPartTitle}}}");
+                var resolvedTermSetId = parser.ParseString($"{{termsetid:{termGroupName}:{termSetName}}}");
+                var resolvedTermStoreId = parser.ParseString($"{{termstoreid:{termStoreName}}}");
 
 
                 Assert.IsTrue(contentTypeId == resolvedContentTypeId);

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -6,6 +6,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using User = OfficeDevPnP.Core.Framework.Provisioning.Model.User;
 using OfficeDevPnP.Core.Diagnostics;
 using Microsoft.SharePoint.Client.Utilities;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -90,7 +91,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         }
                         group.Update();
+                        web.Context.Load(group, g => g.Id, g => g.Title);
                         web.Context.ExecuteQueryRetry();
+                        parser.AddToken(new GroupIdToken(web, group.Title, group.Id));
                     }
                     else
                     {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/GroupIdToken.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/GroupIdToken.cs
@@ -1,0 +1,25 @@
+using Microsoft.SharePoint.Client;
+using System;
+using System.Text.RegularExpressions;
+
+namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    internal class GroupIdToken : TokenDefinition
+    {
+        private readonly int _groupId = 0;
+        public GroupIdToken(Web web, string name, int groupId)
+            : base(web, string.Format("{{groupid:{0}}}", Regex.Escape(name)))
+        {
+            _groupId = groupId;
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _groupId.ToString();
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -203,6 +203,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 _tokens.Add(new RoleDefinitionToken(web, roleDef));
             }
 
+            // Groups
+            web.EnsureProperty(w => w.SiteGroups.Include(g => g.Title, g => g.Id));
+            foreach (var siteGroup in web.SiteGroups)
+            {
+                _tokens.Add(new GroupIdToken(web, siteGroup.Title, siteGroup.Id));
+            }
+            web.EnsureProperty(w => w.AssociatedVisitorGroup).EnsureProperties(g => g.Id, g => g.Title);
+            web.EnsureProperty(w => w.AssociatedMemberGroup).EnsureProperties(g => g.Id, g => g.Title);
+            web.EnsureProperty(w => w.AssociatedOwnerGroup).EnsureProperties(g => g.Id, g => g.Title);
+
+            if (!web.AssociatedVisitorGroup.ServerObjectIsNull.Value)
+            {
+                _tokens.Add(new GroupIdToken(web, "associatedvisitorgroup", web.AssociatedVisitorGroup.Id));
+            }
+            if (!web.AssociatedMemberGroup.ServerObjectIsNull.Value)
+            {
+                _tokens.Add(new GroupIdToken(web, "associatedmembergroup", web.AssociatedMemberGroup.Id));
+            }
+            if (!web.AssociatedOwnerGroup.ServerObjectIsNull.Value)
+            {
+                _tokens.Add(new GroupIdToken(web, "associatedownergroup", web.AssociatedOwnerGroup.Id));
+            }
             var sortedTokens = from t in _tokens
                                orderby t.GetTokenLength() descending
                                select t;

--- a/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -605,6 +605,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\CurrentUserLoginNameToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\KeywordsTermStoreIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ContentTypeIdToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\GroupIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\RoleDefinitionToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\LocalizationToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ResourceEntry.cs" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes
| New sample?      | no 
| Related issues?  | mentioned in issue #503

#### What's in this Pull Request?
Adds a groupid token, which returns the ID of a sitegroup. Syntax is as follows:

{groupid:<groupname>} => returns the group id of the groupname specified or to return the id of an associated group:

{groupid:associatedownergroup}  
{groupid:associatedmembergroup}
{groupid:associatedvisitorgroup}

