### PR TITLE
Fixing issue 756: Provisioning Framework - issue with Directory Handler.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -398,7 +398,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
             Dictionary<String, Dictionary<String, String>> result = null;
 
-            if (directory.MetadataMappingFile != null)
+            if (!string.IsNullOrEmpty(directory.MetadataMappingFile))
             {
                 var metadataPropertiesStream = directory.ParentTemplate.Connector.GetFileStream(directory.MetadataMappingFile);
                 if (metadataPropertiesStream != null)
@@ -421,7 +421,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             var files = directory.ParentTemplate.Connector.GetFiles(directory.Src);
 
-            if (!String.IsNullOrEmpty(directory.IncludedExtensions))
+            if (!String.IsNullOrEmpty(directory.IncludedExtensions) && directory.IncludedExtensions != "*.*")
             {
                 var includedExtensions = directory.IncludedExtensions.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 files = files.Where(f => includedExtensions.Contains($"*{Path.GetExtension(f).ToLower()}")).ToList();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #756 

#### What's in this Pull Request?

Fix issue #756 
MetadataMappingFile is set as Empty when is not present in the XML, and code is expecting Null value.
Also, when IncludedExtensions is not set, is set by default as "*.*" and that pattern is not supported later, when filtering the Files in the Directory.