### PR TITLE
Fix: Site security RoleAssignments and RoleDefinitions provisioning.

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -606,7 +606,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                   template.Security.AdditionalMembers.Any() ||
                                   template.Security.AdditionalOwners.Any() ||
                                   template.Security.AdditionalVisitors.Any() ||
-                                  template.Security.SiteGroups.Any());
+                                  template.Security.SiteGroups.Any() ||
+                                  template.Security.SiteSecurityPermissions.RoleAssignments.Any() ||
+                                  template.Security.SiteSecurityPermissions.RoleDefinitions.Any());
                 if (_willProvision == true)
                 {
                     // if not subweb and site inheritance is not broken


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #656 

#### What's in this Pull Request?

Fixes site security provisioning when you only want to provision role assignments or role definitions (OfficeDev/PnP-Sites-Core#656).