### PR TITLE
Add ContentTypeId tokens also in case of subsites by looping through …

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -95,9 +95,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             // Add ContentTypes
-            web.Context.Load(web.ContentTypes, cs => cs.Include(ct => ct.StringId, ct => ct.Name));
+            web.Context.Load(web.AvailableContentTypes, cs => cs.Include(ct => ct.StringId, ct => ct.Name));
             web.Context.ExecuteQueryRetry();
-            foreach (var ct in web.ContentTypes)
+            foreach (var ct in web.AvailableContentTypes)
             {
                 _tokens.Add(new ContentTypeIdToken(web, ct.Name, ct.StringId));
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #781

#### What's in this Pull Request?

Add contenttypeid tokens based on Web.AvailabelContentTypes instead of Web.ContentTypes so contenttypeid replacement also works for subsites.

