### PR TITLE
Updated to allow for the pageName to include relative path info.

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/PageExtensions.cs
@@ -1142,7 +1142,18 @@ namespace Microsoft.SharePoint.Client
             {
                 title = pageName;
             }
-
+            //Allow users to specify the filename as a relativepath within the pages library ie: folder/page.aspx would provision
+            //a new publishing page within /Pages/folder/ named page.aspx
+            if(pageName.Contains("/") && folder == null) {
+                var context = web.Context as ClientContext;
+                
+                //The page name includes a relative path. Generate a Folder object, then we can put the page into the correct folder.
+                var folderName = pageName.Substring(0, pageName.LastIndexOf("/")-1);
+                folder = web.EnsureFolder(folderName); 
+                context.ExecuteQueryRetry(); 
+                //grab the last bit, (the proper page name
+                pageName = pageName.Substring(pageName.LastIndexOf("/")+1);
+            }
             // Fix page name, if needed
             pageName = pageName.ReplaceInvalidUrlChars("-");
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes? |
| New sample? | no |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |
#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.

When using OfficePnp Powershell and adding publishing pages (Add‑SPOPublishingPage), it is much easier to allow the relative path to be supplied as part of the page name parameter. The name parameter "folder/page.aspx" should provision a page in /Pages/folder/page.aspx path. Currently since the / is an invalid character we instead get /Pages/folder-page.aspx. Also since the / character is a standard separator seems like an intuitive addition.
