### PR TITLE
Added null cheks for some of the web settings so that settings not pr…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -229,19 +229,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         web.CustomMasterUrl = customMasterUrl;
                     }
-                    if (!string.IsNullOrEmpty(parser.ParseString(webSettings.Title)))
+                    if (webSettings.Title != null)
                     {
                         web.Title = parser.ParseString(webSettings.Title);
                     }
-                    web.Description = parser.ParseString(webSettings.Description);
-                    web.SiteLogoUrl = parser.ParseString(webSettings.SiteLogo);
+                    if (webSettings.Description != null)
+                    {
+                        web.Description = parser.ParseString(webSettings.Description);
+                    }
+                    if (webSettings.SiteLogo != null)
+                    {
+                        web.SiteLogoUrl = parser.ParseString(webSettings.SiteLogo);
+                    }
                     var welcomePage = parser.ParseString(webSettings.WelcomePage);
                     if (!string.IsNullOrEmpty(welcomePage))
                     {
                         web.RootFolder.WelcomePage = welcomePage;
                         web.RootFolder.Update();
                     }
-                    web.AlternateCssUrl = parser.ParseString(webSettings.AlternateCSS);
+                    if (webSettings.AlternateCSS != null)
+                    {
+                        web.AlternateCssUrl = parser.ParseString(webSettings.AlternateCSS);
+                    }
 
                     web.Update();
                     web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no

Added null cheks for some of the web settings so that settings not provided in the provisioning template does not overwrite settings on the web. This also supports clearing out the settings if it is left empty in the template. This was not possible for web title before.

Example 1:
`...`
`<pnp:WebSettings WelcomePage="Pages/default.aspx"/>`
`...`

This will no longer reset web description, site logo, or alternate css.

Example 2:
`...`
`<pnp:WebSettings WelcomePage="Pages/default.aspx" Title=""/>`
`...`

Same as previous example, but now makes it possible to set the web title to an empty string.
