### PR TITLE
Fix to TokenizeFieldFormula

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -3,6 +3,7 @@ using Microsoft.SharePoint.Client.Taxonomy;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -58,19 +59,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var formulaString = formula.Value;
                 if (formulaString != null)
                 {
-                    // Remove duplicates and sort descending
-                    var fieldRefs = schemaElement.Descendants("FieldRef").GroupBy(f => f.Attribute("Name").Value, (key, group) => group.FirstOrDefault()).OrderByDescending(f => f.Attribute("Name").Value);
+                    // Remove duplicate FieldRefs
+                    var fieldRefs = schemaElement.Descendants("FieldRef").GroupBy(f => f.Attribute("Name").Value, (key, group) => group.FirstOrDefault());
                     foreach (var fieldRef in fieldRefs)
                     {
-                        var fieldID = fieldRef.Attribute("ID").Value;
                         var fieldInternalName = fieldRef.Attribute("Name").Value;
-                        formulaString = formulaString.Replace(fieldInternalName, string.Format("[{{fieldtitle:{0}}}]", fieldID));
-                    }
-                    foreach (var fieldRef in fieldRefs)
-                    {
-                        var fieldID = fieldRef.Attribute("ID").Value;
-                        var fieldInternalName = fieldRef.Attribute("Name").Value;
-                        formulaString = formulaString.Replace(fieldID, fieldInternalName);
+                        formulaString = Regex.Replace(formulaString, $@"\b{fieldInternalName}\b", $"[{{fieldtitle:{fieldInternalName}}}]");
                     }
 
                     var fieldRefParent = schemaElement.Descendants("FieldRefs");

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -58,15 +58,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 var formulaString = formula.Value;
                 if (formulaString != null)
                 {
-                    var fieldRefs = schemaElement.Descendants("FieldRef");
+                    // Remove duplicates and sort descending
+                    var fieldRefs = schemaElement.Descendants("FieldRef").GroupBy(f => f.Attribute("Name").Value, (key, group) => group.FirstOrDefault()).OrderByDescending(f => f.Attribute("Name").Value);
                     foreach (var fieldRef in fieldRefs)
                     {
+                        var fieldID = fieldRef.Attribute("ID").Value;
                         var fieldInternalName = fieldRef.Attribute("Name").Value;
-                        formulaString = formulaString.Replace(fieldInternalName, string.Format("[{{fieldtitle:{0}}}]", fieldInternalName));
+                        formulaString = formulaString.Replace(fieldInternalName, string.Format("[{{fieldtitle:{0}}}]", fieldID));
                     }
+                    foreach (var fieldRef in fieldRefs)
+                    {
+                        var fieldID = fieldRef.Attribute("ID").Value;
+                        var fieldInternalName = fieldRef.Attribute("Name").Value;
+                        formulaString = formulaString.Replace(fieldID, fieldInternalName);
+                    }
+
                     var fieldRefParent = schemaElement.Descendants("FieldRefs");
                     fieldRefParent.Remove();
-
                 }
                 formula.Value = formulaString;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| New sample? | no |
| Related issues? | n/a |
#### What's in this Pull Request?

Consider the following calculated field.

```
<Field Type="Calculated" ... >
    <Formula>
        =my_x0020_number-(my_x0020_number/100*-my_x0020_number_x0020_percent)
    </Formula>
    <FieldRefs>
        <FieldRef Name="my_x0020_number" ID="{1a0e07ec-0bc3-45bd-94a3-a748f9f047b5}" />
        <FieldRef Name="my_x0020_number" ID="{1a0e07ec-0bc3-45bd-94a3-a748f9f047b5}" />
        <FieldRef Name="my_x0020_number_x0020_percent" ID="{fc65dffa-fb55-49e5-9128-4913513cc9b4}" />
    </FieldRefs>
</Field>
```

After tokenization the Formula will be
=[{fieldtitle:[{fieldtitle:my_x0020_number}]}]-([{fieldtitle:[{fieldtitle:my_x0020_number}]}]/100*-[{fieldtitle:my_x0020_number_x0020_percent}])

The tokenized formula contains two issues.
1. Double tokenization because we have two FieldRef to the same field
2. Wrong string replacement when part of the fields InternalName is the same

Issue 1 is fixed by removing duplicated FieldRefs
Issue 2 is fixed by using RegEx
