### PR TITLE
Ignore case of login name for web.IsUserInGroup() extension method

### DIFF
--- a/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
+++ b/Core/OfficeDevPnP.Core/AppModelExtensions/SecurityExtensions.cs
@@ -1092,9 +1092,12 @@ namespace Microsoft.SharePoint.Client
             web.Context.Load(group);
             web.Context.Load(users);
             web.Context.ExecuteQueryRetry();
-            if (group != null)
+
+            if (users.AreItemsAvailable)
             {
-                result = users.Any(u => u.LoginName.Contains(userLoginName));
+                result = users.Any(u => 
+                  u.LoginName.ToLowerInvariant().Contains(userLoginName.ToLowerInvariant())
+                );
             }
 
             return result;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?

Ignore case in web.IsUserInGroup() extension method. Currently this is a problem for on prem.

```
web.IsUserInGroup("groupName", "DOMAIN\\user"); // => false
web.IsUserInGroup("groupName", "domain\\user"); // => true
```
