### PR TITLE
Fix parsing of calculated fields with references to fields not yet created

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -203,9 +203,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.Load(field, f => f.TypeAsString, f => f.DefaultValue, f => f.InternalName, f => f.Title);
                 web.Context.ExecuteQueryRetry();
 
-                // Add newly created field to token set, this allows to create a field + use it in a formula in the same provisioning template
-                parser.AddToken(new FieldTitleToken(web, field.InternalName, field.Title));
-
                 bool isDirty = false;
 #if !SP2013
                 if (originalFieldXml.ContainsResourceToken())
@@ -236,7 +233,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     var taxField = web.Context.CastTo<TaxonomyField>(field);
                     ValidateTaxonomyFieldDefaultValue(taxField);
                 }
-
             }
             else
             {
@@ -246,8 +242,6 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 throw new Exception(string.Format("The field was found invalid: {0}", tokenString));
             }
         }
-
-       
 
         private static void ValidateTaxonomyFieldDefaultValue(TaxonomyField field)
         {

--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -1,15 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.SharePoint.Client;
+﻿using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Taxonomy;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
+using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.Extensions;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
-using System.Resources;
+using System;
 using System.Collections;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Resources;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -44,6 +45,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public TokenParser(Web web, ProvisioningTemplate template)
         {
             web.EnsureProperties(w => w.ServerRelativeUrl, w => w.Language);
+            var cultureName = new CultureInfo((int)web.Language).Name;
 
             _web = web;
 
@@ -193,6 +195,26 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     LocalizationToken token = new LocalizationToken(web, key, entries);
 
                     _tokens.Add(token);
+                }
+            }
+
+            // Add FieldTitleToken for fields to be created so that they are available for calculated fields
+            foreach (var field in template.SiteFields.Except(template.SiteFields.Where(s => fields.Any(sf => sf.InternalName.Equals(XElement.Parse(s.SchemaXml).Attribute("Name").Value)))))
+            {
+                var element = XElement.Parse(field.SchemaXml);
+                var displayName = element.Attribute("DisplayName")?.Value;
+
+                if (!string.IsNullOrEmpty(displayName))
+                {
+                    if (displayName.ContainsResourceToken())
+                    {
+                        // Add FieldTitleToken for the Web language
+                        var resourceValue = GetResourceTokenResourceValues(displayName).FirstOrDefault(r => r.Item1.Equals(cultureName, StringComparison.InvariantCultureIgnoreCase));
+
+                        _tokens.Add(new FieldTitleToken(web, element.Attribute("Name").Value, resourceValue != null ? resourceValue.Item2 : displayName));
+                    }
+                    else
+                        _tokens.Add(new FieldTitleToken(web, element.Attribute("Name").Value, displayName));
                 }
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #537 and #744 

#### What's in this Pull Request?

Please see #537 and #744 for a description of the problem.

Instead of adding a FieldTitleToken to the TokenParser after a field is created, this PR adds the token in the constructor of the TokenParser. This will make the tokens available when parsing a calculated field where the referenced field(s) are not yet created.
