### PR TITLE
Support both "\" and "/" as path separators in SharePointConnector

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -53,6 +53,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');
 
             this.AddParameter(CLIENTCONTEXT, clientContext);
             this.AddParameterAsString(CONNECTIONSTRING, connectionString);
@@ -82,6 +83,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');
 
             List<string> result = new List<string>();
 
@@ -131,6 +133,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             {
                 throw new ArgumentException("container");
             }
+            container = container.Replace('\\', '/');
 
             List<string> result = new List<string>();
 
@@ -183,6 +186,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw new ArgumentException("fileName");
             }
 
+            if (container != null) { 
+                container = container.Replace('\\', '/');
+            }
+
             string result = null;
             MemoryStream stream = null;
             try
@@ -231,6 +238,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw new ArgumentException("fileName");
             }
 
+            if (container != null)
+            {
+                container = container.Replace('\\', '/');
+            }
+
             return GetFileFromStorage(fileName, container);
         }
 
@@ -252,6 +264,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <param name="stream">Stream containing the file contents</param>
         public override void SaveFileStream(string fileName, string container, Stream stream)
         {
+            if (container != null)
+            {
+                container = container.Replace('\\', '/');
+            }
+
             try
             {
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
@@ -316,6 +333,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <param name="container">Name of the container to delete the file from</param>
         public override void DeleteFile(string fileName, string container)
         {
+            if (container != null)
+            {
+                container = container.Replace('\\', '/');
+            }
+
             try
             {
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
@@ -346,6 +368,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
 
         public override string GetFilenamePart(string fileName)
         {
+            fileName = fileName.Replace('\\', '/');
             if (fileName.IndexOf(@"/") != -1)
             {
                 var parts = fileName.Split(new[] { @"/" }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| New sample? | no |
| Related issues? | mentioned in #496 |
#### What's in this Pull Request?

Added support for backslash (`\`) as a path separator to the PnP Provisioning Engine's `SharePointConnector`. 

Files which contain paths in their `Src`-attribute cannot currently be imported using the `SharePointConnector` because the Files-handler always adds a  backslash (`\`) in the path if the `Src`-attrbute contains folders. ([source](https://github.com/OfficeDev/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs#L440)). As the current `SharePointConnector` supports only forward slash (`/`) as the path separator, it causes an error.

Adding support for backslashes (`\`) in `SharePointConnector` fixes this problem and also makes it easier to use the same template both using the `SharePointConnector` and `FileSystemConnector` since both connectors now support the same separator character (backslash).

In the pull request I replace all backslashes to forwards slashes in all public methods, constructors and properties of the `SharePointConnector`. This ensures that the connector will work correctly even if the passed in container parameter is mixing both forward and backward slashes in the path. (This path with mixed separators results for example from the hardcoded backslash-separator in the `ObjectFiles`-handler)
