### PR TITLE
File level implementation

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -119,11 +119,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             }
                         }
 
-                        if (checkedOut)
-                        {
-                            targetFile.CheckIn("", CheckinType.MajorCheckIn);
-                            web.Context.ExecuteQueryRetry();
-                        }
+                        //OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel string values map to Microsoft.SharePoint.Client.FileLevel
+                        targetFile.PublishFileToLevel((Microsoft.SharePoint.Client.FileLevel)Enum.Parse(typeof(Microsoft.SharePoint.Client.FileLevel), file.Level.ToString()));
 
                         // Don't set security when nothing is defined. This otherwise breaks on files set outside of a list
                         if (file.Security != null &&


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | -

#### What's in this Pull Request?

Implemented setting file publishing level (Checkout/Draft/Published) in file provisioning.
 
Microsoft.SharePoint.Client.FileLevel string values map to OfficeDevPnP.Core.Framework.Provisioning.Model.FileLevel, is the PnP enum really needed? I think it could be replaced everywhere with Microsoft.SharePoint.Client.FileLevel, but didn't have time to do it now.