### PR TITLE
List instance's view titles can now be localized

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -296,7 +296,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         foreach (var view in list.Views)
                         {
 
-                            CreateView(web, view, existingViews, createdList, scope);
+                            CreateView(web, view, existingViews, createdList, scope, parser);
 
                         }
 
@@ -350,7 +350,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
-        private void CreateView(Web web, View view, Microsoft.SharePoint.Client.ViewCollection existingViews, List createdList, PnPMonitoredScope monitoredScope)
+        private void CreateView(Web web, View view, Microsoft.SharePoint.Client.ViewCollection existingViews, List createdList, PnPMonitoredScope monitoredScope, TokenParser parser)
         {
             try
             {
@@ -361,17 +361,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     throw new ApplicationException("Invalid View element, missing a valid value for the attribute DisplayName.");
                 }
-
                 monitoredScope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ListInstances_Creating_view__0_, displayNameElement.Value);
-                var existingView = existingViews.FirstOrDefault(v => v.Title == displayNameElement.Value);
 
+
+                var viewTitle = parser.ParseString(displayNameElement.Value);
+                var existingView = existingViews.FirstOrDefault(v => v.Title == viewTitle);
                 if (existingView != null)
                 {
                     existingView.DeleteObject();
                     web.Context.ExecuteQueryRetry();
                 }
-
-                var viewTitle = displayNameElement.Value;
 
                 // Type
                 var viewTypeString = viewElement.Attribute("Type") != null ? viewElement.Attribute("Type").Value : "None";


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| New sample? | no |
| Related issues? |  |
#### What's in this Pull Request?

In the provisioning framework, views couldn't have their display name localized.

 <View Name="{2ACBD28D-D2A2-4F97-AC44-DE56F5D7C4E4}" DefaultView="TRUE" Type="HTML" DisplayName="{resource:Glossary}"... did not work and was just giving a view whose display name is {resource:Glossary} in SharePoint. It now works.
