### PR TITLE
Bugfix : List instance datarows did not work if list instance's title…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -40,7 +40,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 						{
 							scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ListInstancesDataRows_Processing_data_rows_for__0_, listInstance.Title);
 							// Retrieve the target list
-							var list = web.Lists.GetByTitle(listInstance.Title);
+							var list = web.Lists.GetByTitle(parser.ParseString(listInstance.Title));
 							web.Context.Load(list);
 
 							// Retrieve the fields' types from the list


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| New sample? | no |
| Related issues? |  |
#### What's in this Pull Request?

There was a bug on datarows provisioning in the provisioning framework. Happening if list instance's title was localized (e.g. {resource:ListTitle}). The datarows provisining did get the list by title, using unparsed XML value. List {resource:ListTitle} was then not found and data rows could not be provisioned.
