### PR TITLE
Possible fix to issue #754

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
@@ -254,6 +254,12 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             {
                 xml = Regex.Replace(xml, list.Id.ToString(), string.Format("{{listid:{0}}}", list.Title), RegexOptions.IgnoreCase);
             }
+
+            //some webparts already contains the site URL using ~sitecollection token (i.e: CQWP)
+            xml = Regex.Replace(xml, "\"~sitecollection/(.)*\"", "\"{site}\"", RegexOptions.IgnoreCase);
+            xml = Regex.Replace(xml, "'~sitecollection/(.)*'", "'{site}'", RegexOptions.IgnoreCase);
+            xml = Regex.Replace(xml, ">~sitecollection/(.)*<", ">{site}<", RegexOptions.IgnoreCase);
+
             xml = Regex.Replace(xml, web.Id.ToString(), "{siteid}", RegexOptions.IgnoreCase);
             xml = Regex.Replace(xml, "(\"" + web.ServerRelativeUrl + ")(?!&)", "\"{site}", RegexOptions.IgnoreCase);
             xml = Regex.Replace(xml, "'" + web.ServerRelativeUrl, "'{site}", RegexOptions.IgnoreCase);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #754 

#### What's in this Pull Request?

This PR adds a possible fix to issue #754 
However, there is a use case that the Engine cannot cover regarding export/import of Content Query WebParts: 
When the CQWP is in the root site, and is pointing to a subsite web, the property would be:

```xml
<property name="WebUrl" type="string">~sitecollection/subsite</property>
```

As we are exporting the root site, and the CQWP is pointing to a subsite that won't exist when importing the template to the new site, this fix won't work (current code without this fix won't work either). I'm afraid we can't cover that use case anyway, as it depends on a subsite.

However, if we are exporting a CQWP in a subsite, that is pointing to the same subsite, this fix will work, as it will replace:

```xml
<property name="WebUrl" type="string">~sitecollection/subsite</property>
```

by

```xml
<property name="WebUrl" type="string">{site}</property>
```

and it will be pointing to the same subsite, when the template is imported to a new subsite.

Hope it makes sense. Leave any question here.

/cc @PieterVeenstra @VesaJuvonen 