### PR TITLE
SharePointConnector: fixed CAML query for retrieving folders

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -140,7 +140,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 string folders = GetUrlFolders(container);
 
                 CamlQuery camlQuery = new CamlQuery();
-                camlQuery.ViewXml = @"<View><Query><Where><Eq><FieldRef Name='ContentType' /><Valye Type='Text'>Folder</Value></Eq></Where></Query></View>";
+                camlQuery.ViewXml = @"<View><Query><Where><Eq><FieldRef Name='ContentType' /><Value Type='Text'>Folder</Value></Eq></Where></Query></View>";
 
                 if (folders.Length > 0)
                 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no 
| New sample?      | no


#### What's in this Pull Request?

Fixed incorrect CAML query tag <Valye> to <Value> in SharePointConnector.GetFolders(string)

