### PR TITLE
Set site collection locale to English in tests

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/FunctionalTestBase.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/FunctionalTestBase.cs
@@ -174,6 +174,9 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional
                     Title = "Test",
                     Description = "Test site collection",
                     SiteOwnerLogin = siteOwnerLogin,
+                    Lcid = 1033,
+                    StorageMaximumLevel = 100,
+                    UserCodeMaximumLevel = 0
                 };
 
                 tenant.CreateSiteCollection(siteToCreate, false, true);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

If the default site collection uses tenant language, for example Norwegian, then localization tests will fail as they assume 1033/English to be the default.

I also set the the initial quota for storage to 100mb and sandbox resources to 0, to play nice.